### PR TITLE
Add No-DB Support

### DIFF
--- a/app/config/default.json
+++ b/app/config/default.json
@@ -1,7 +1,6 @@
 {
   "db": {
     "database": "coms",
-    "enabled": "true",
     "host": "localhost",
     "port": "5432",
     "username": "app"

--- a/app/src/db/dataConnection.js
+++ b/app/src/db/dataConnection.js
@@ -167,6 +167,8 @@ class DataConnection {
       } catch (e) {
         log.error(e);
       }
+    } else {
+      if (cb) cb();
     }
   }
 

--- a/app/src/services/index.js
+++ b/app/src/services/index.js
@@ -1,5 +1,30 @@
+const config = require('config');
+
+/**
+ * @function featureNoDb
+ * Changes all service methods to be no-op functions if there is no database enabled
+ * @param {object} service The service
+ * @returns {object} Yields `service` with normal or no-op methods depending if database support is enabled or not
+ */
+function featureNoDb(service) {
+  if (config.has('db.enabled')) { // Passthrough
+    return service;
+  } else { // Make all functions no-op resolvable promises
+    const nullSvc = {};
+    Object.keys(service).forEach(attr => {
+      if (typeof service[attr] === 'function') {
+        nullSvc[attr] = async () => Promise.resolve({});
+      } else {
+        nullSvc[attr] = service[attr];
+      }
+    });
+    return nullSvc;
+  }
+}
+
 module.exports = {
-  recordService: require('./record'),
+  featureNoDb: featureNoDb,
+  recordService: featureNoDb(require('./record')),
   storageService: require('./storage'),
-  userService: require('./user')
+  userService: featureNoDb(require('./user')),
 };


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

<!-- Describe your changes in detail -->
This PR adds the option for COMS to run without a DB in noAuth or basicAuth modes. This allows users the option to choose to have simpler infrastructure deployment at the cost of the following features:
- Object/User permissions are not supported
- User tracking/auditing is not supported
- Planned metadata/tagging reverse searching is not supported

Should any of these features be needed, you will need to provide a Postgres-compatible database and operate in either oidcAuth or fullAuth modes.
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
[SHOWCASE-2359](https://apps.nrs.gov.bc.ca/int/jira/browse/SHOWCASE-2359)

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->