### PR TITLE
Expose S3 expiresIn parameter to readObject operations

### DIFF
--- a/app/src/controllers/object.js
+++ b/app/src/controllers/object.js
@@ -186,7 +186,7 @@ const controller = {
       };
 
       // Download through service
-      if (req.query.download) {
+      if (!req.query.expiresIn && req.query.download) {
         const response = await storageService.readObject(data);
 
         // Set Headers
@@ -203,7 +203,10 @@ const controller = {
 
       // Download via redirect
       else {
-        const response = await storageService.readSignedUrl(data);
+        const response = await storageService.readSignedUrl({
+          expiresIn: req.query.expiresIn,
+          ...data
+        });
         res.status(302).set('Location', response).end();
       }
     } catch (e) {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

<!-- Describe your changes in detail -->
In the event the user specifies a custom expiresIn query parameter, the
endpoint will generate a direct S3 link with the specified expiresIn, even
if the download query parameter is also specified. This is because if
expiresIn is specified, it does not make sense for COMS to handle the
file transfer directly as it will not be able to temporally restrict access
outside of JWT expirations.
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
[SHOWCASE-2443](https://apps.nrs.gov.bc.ca/int/jira/browse/SHOWCASE-2443)

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->