### PR TITLE
Bugfix Keycloak config crash in non-OIDC Auth modes

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -5,7 +5,6 @@ const express = require('express');
 const Problem = require('api-problem');
 
 const { AuthMode } = require('./src/components/constants');
-const keycloak = require('./src/components/keycloak');
 const log = require('./src/components/log')(module.filename);
 const httpLogger = require('./src/components/log').httpLogger;
 const { getAppAuthMode } = require('./src/components/utils');
@@ -76,6 +75,7 @@ if (state.authMode === AuthMode.OIDCAUTH || state.authMode === AuthMode.FULLAUTH
   }
 
   // Use Keycloak OIDC Middleware
+  const keycloak = require('./src/components/keycloak');
   app.use(keycloak.middleware());
 }
 

--- a/app/src/db/dataConnection.js
+++ b/app/src/db/dataConnection.js
@@ -2,7 +2,6 @@ const config = require('config');
 const Knex = require('knex');
 const { Model } = require('objection');
 
-const knexfile = require('../../knexfile');
 const log = require('../components/log')(module.filename);
 const models = require('./models');
 const { tableNames } = require('./models/utils');
@@ -15,6 +14,7 @@ class DataConnection {
   constructor() {
     if (!DataConnection.instance) {
       if (config.has('db.enabled')) {
+        const knexfile = require('../../knexfile');
         this.knex = Knex(knexfile);
       }
       DataConnection.instance = this;

--- a/app/src/middleware/authentication.js
+++ b/app/src/middleware/authentication.js
@@ -4,7 +4,6 @@ const basicAuth = require('express-basic-auth');
 const jwt = require('jsonwebtoken');
 
 const { AuthType } = require('../components/constants');
-const keycloak = require('../components/keycloak');
 const { userService } = require('../services');
 
 /**
@@ -75,6 +74,7 @@ const currentUser = async (req, res, next) => {
             issuer: `${config.get('keycloak.serverUrl')}/realms/${config.get('keycloak.realm')}`
           });
         } else {
+          const keycloak = require('../components/keycloak');
           isValid = await keycloak.grantManager.validateAccessToken(bearerToken);
         }
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

<!-- Describe your changes in detail -->
There is an unintended bug where COMS chokes with startup where it is
expecting the keycloak.clientId configuration. The expected behavior is
to not look for that config unless keycloak.enabled is true first. We can
ensure this pre-check behavior by delaying the import of the keycloak
component and having it only execute within the appropriate conditionals.
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
[SHOWCASE-2598](https://apps.nrs.gov.bc.ca/int/jira/browse/SHOWCASE-2598)

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->