### PR TITLE
Version-related API structure and basic unit tests

### DIFF
--- a/app/src/docs/v1.api-spec.yaml
+++ b/app/src/docs/v1.api-spec.yaml
@@ -96,12 +96,13 @@ paths:
           $ref: "#/components/responses/Error"
     get:
       summary: Search for objects
-      description: >-
+      description: |
         Returns a list of objects. If the request is BasicAuth authenticated,
         all search and filtered results will appear. However, If the request is
         BearerAuth authenticated, only objects the user has at least one
         permission associated with them will appear in addition to their
-        filtering parameters.
+        filtering parameters.\
+        Search will look for a match in all versions of an object.
       operationId: searchObjects
       tags:
         - Object
@@ -217,7 +218,9 @@ paths:
           $ref: "#/components/responses/Error"
     post:
       summary: Updates an Object
-      description: Updates the object in the configured object storage.
+      description: |
+        Updates the object in the configured object storage.\
+        Create a new version if object storage has versioning enabled
       operationId: updateObject
       tags:
         - Object
@@ -267,10 +270,13 @@ paths:
         default:
           $ref: "#/components/responses/Error"
     delete:
-      summary: Deletes the object
-      description: >-
-        Completely deletes the object from S3 and clears all database references
-        to it. WARNING: This is not a reversible operation!
+      summary: Deletes an object or a version of object
+      description: |
+        This endpoint can be used to:
+        * delete an object (and remove record in COMS database)
+        * delete a specific version of an object
+        * soft-delete an object
+        * restore a soft-deleted object
       operationId: deleteObject
       tags:
         - Object
@@ -1042,6 +1048,7 @@ components:
             type:
               example: https://httpstatuses.com/501
     Response-ObjectDeleted:
+      title: Object Deleted
       type: object
       properties:
         $metadata:
@@ -1125,6 +1132,7 @@ components:
             type:
               example: https://httpstatuses.com/422
     Response-VersionDeleted:
+      title: Version Deleted
       type: object
       properties:
         $metadata:

--- a/app/src/docs/v1.api-spec.yaml
+++ b/app/src/docs/v1.api-spec.yaml
@@ -96,13 +96,11 @@ paths:
           $ref: "#/components/responses/Error"
     get:
       summary: Search for objects
-      description: |
-        Returns a list of objects. If the request is BasicAuth authenticated,
-        all search and filtered results will appear. However, If the request is
-        BearerAuth authenticated, only objects the user has at least one
-        permission associated with them will appear in addition to their
-        filtering parameters.\
-        Search will look for a match in all versions of an object.
+      description: >-
+        Returns a list of objects matching all search criteria across all known versions of objects.
+        If the request is BasicAuth authenticated, all search and filtered results will appear.
+        However, If the request is BearerAuth authenticated, only objects that the user has at least one
+        permission associated with, will appear in addition to their filtering parameters.
       operationId: searchObjects
       tags:
         - Object
@@ -218,9 +216,10 @@ paths:
           $ref: "#/components/responses/Error"
     post:
       summary: Updates an Object
-      description: |
-        Updates the object in the configured object storage.\
-        Create a new version if object storage has versioning enabled
+      description: >-
+        Updates the object in the configured object storage. If the object storage
+        supports versioning, a new version will be generated instead
+        of overwriting the existing contents.
       operationId: updateObject
       tags:
         - Object
@@ -271,12 +270,12 @@ paths:
           $ref: "#/components/responses/Error"
     delete:
       summary: Deletes an object or a version of object
-      description: |
-        This endpoint can be used to:
-        * delete an object (and remove record in COMS database)
-        * delete a specific version of an object
-        * soft-delete an object
-        * restore a soft-deleted object
+      description: >-
+        Deletes the specified object (or version) from S3. If the object storage supports
+        versioning, precise S3 version stack manipulation is supported, including
+        soft-deletion and soft-restore. Hard-deletions on S3 are also supported. For more
+        details on general S3 version behavior, visit
+        https://docs.aws.amazon.com/AmazonS3/latest/userguide/DeletingObjectVersions.html
       operationId: deleteObject
       tags:
         - Object

--- a/app/tests/unit/controllers/object.spec.js
+++ b/app/tests/unit/controllers/object.spec.js
@@ -1,0 +1,112 @@
+const Problem = require('api-problem');
+const { AuthType } = require('../../../src/components/constants');
+
+const controller = require('../../../src/controllers/object');
+const { storageService, objectService, versionService } = require('../../../src/services');
+
+const mockResponse = () => {
+  const res = {};
+  res.status = jest.fn().mockReturnValue(res);
+  res.json = jest.fn().mockReturnValue(res);
+  return res;
+};
+
+// Mock config library - @see {@link https://stackoverflow.com/a/64819698}
+jest.mock('config');
+
+const storageDeleteObjectSpy = jest.spyOn(storageService, 'deleteObject');
+const objectDeleteSpy = jest.spyOn(objectService, 'delete');
+const versionCreateSpy = jest.spyOn(versionService, 'create');
+const versionDeleteSpy = jest.spyOn(versionService, 'delete');
+const versionListSpy = jest.spyOn(versionService, 'list');
+
+
+const res = mockResponse();
+
+
+describe('deleteObject', () => {
+
+  // request is to delete an object (no versionId query parameter passed)
+  const req = {
+    currentUser: { authType: AuthType.BEARER, tokenPayload: { sub: 'testsub' } },
+    params: { objId: 'xyz-789' },
+    query: {}
+  };
+  const next = jest.fn();
+
+  // response from S3
+  const DeleteMarker = {
+    DeleteMarker: true,
+    VersionId: '1234'
+  };
+
+  it('should call version service to create a delete marker in db', async () => {
+    storageDeleteObjectSpy.mockReturnValue(DeleteMarker);
+
+    await controller.deleteObject(req, res, next);
+
+    expect(versionCreateSpy).toHaveBeenCalledTimes(1);
+    expect(versionCreateSpy).toHaveBeenCalledWith([{
+      id: 'xyz-789',
+      DeleteMarker: true,
+      VersionId: '1234',
+      mimeType: null,
+      originalName: null
+    }], 'testsub');
+  });
+
+  it('should delete object if versioning not enabled', async () => {
+    // if versioning disabled, S3 delete response does not include a DeleteMarker
+    storageDeleteObjectSpy.mockReturnValue({});
+
+    await controller.deleteObject(req, res, next);
+
+    expect(versionCreateSpy).toHaveBeenCalledTimes(0);
+    expect(objectDeleteSpy).toHaveBeenCalledTimes(1);
+    expect(objectDeleteSpy).toHaveBeenCalledWith('xyz-789');
+  });
+
+  it('should return the storage service response', async () => {
+    storageDeleteObjectSpy.mockReturnValue(DeleteMarker);
+    versionCreateSpy.mockReturnValue({});
+
+    await controller.deleteObject(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith(DeleteMarker);
+    expect(next).toHaveBeenCalledTimes(0);
+  });
+
+
+  it('should call version service to delete a version', async () => {
+
+    // --- version delete request includes versionId query param
+    req.query = { versionId: '123' };
+
+    storageDeleteObjectSpy.mockReturnValue({
+      VersionId: '123'
+    });
+
+    await controller.deleteObject(req, res, next);
+    expect(versionDeleteSpy).toHaveBeenCalledTimes(1);
+    expect(versionDeleteSpy).toHaveBeenCalledWith('xyz-789', '123');
+  });
+
+  it('should delete object if object has no other remaining versions', async () => {
+    versionListSpy.mockReturnValue([]);
+    await controller.deleteObject(req, res, next);
+
+    expect(versionListSpy).toHaveBeenCalledTimes(1);
+    expect(objectDeleteSpy).toHaveBeenCalledTimes(1);
+    expect(objectDeleteSpy).toHaveBeenCalledWith('xyz-789');
+  });
+
+  it('should return a problem if an exception happens', async () => {
+    storageDeleteObjectSpy.mockImplementationOnce(() => { throw new Error(); });
+
+    await controller.deleteObject(req, res, next);
+    expect(storageDeleteObjectSpy).toHaveBeenCalledTimes(1);
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(next).toHaveBeenCalledWith(new Problem(502, 'Unknown ObjectService Error'));
+  });
+});

--- a/app/tests/unit/services/storage.spec.js
+++ b/app/tests/unit/services/storage.spec.js
@@ -1,5 +1,6 @@
 const {
   DeleteObjectCommand,
+  GetBucketVersioningCommand,
   GetObjectCommand,
   HeadBucketCommand,
   HeadObjectCommand,
@@ -75,12 +76,28 @@ describe('headBucket', () => {
     s3ClientMock.on(HeadBucketCommand).resolves({});
   });
 
-  it('should send a head object command', () => {
+  it('should send a head bucket command', () => {
     const result = service.headBucket();
 
     expect(result).toBeTruthy();
     expect(s3ClientMock.calls()).toHaveLength(1);
     expect(s3ClientMock.commandCalls(HeadBucketCommand, {
+      Bucket: bucket
+    }, true)).toHaveLength(1);
+  });
+});
+
+describe('getBucketVersioning', () => {
+  beforeEach(() => {
+    s3ClientMock.on(GetBucketVersioningCommand).resolves({});
+  });
+
+  it('should send a get bucket versioning command', () => {
+    const result = service.getBucketVersioning();
+
+    expect(result).toBeTruthy();
+    expect(s3ClientMock.calls()).toHaveLength(1);
+    expect(s3ClientMock.commandCalls(GetBucketVersioningCommand, {
       Bucket: bucket
     }, true)).toHaveLength(1);
   });


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

ticket:[ https://apps.nrs.gov.bc.ca/int/jira/browse/SHOWCASE-2648]( https://apps.nrs.gov.bc.ca/int/jira/browse/SHOWCASE-2648)

* Edited version related parts of API spec

* Added unit tests for 
  * the deleteObject method in the object controller dealing with versions.
  * getBucketVersioning method in storage service

* tested in different auth and db modes and without versioning enabled

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
Documentation (non-breaking change with enhancements to documentation)
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

i wonder if we should remove the object.active field from db responses. (maybe override the model somehow)
and `active=true|false` parameter for the object/search endpoint in the API spec (and  for now (keep it in code) but not advertise it. You cant update that field in the db, its always true. it might confuse people, especially with the delete/soft-delete stuff. when we figure out what we can use active for, add it back in.