### PR TITLE
Bugfix: Offer decoupled configmap generation in Helm chart

### DIFF
--- a/charts/coms/Chart.yaml
+++ b/charts/coms/Chart.yaml
@@ -3,7 +3,7 @@ name: common-object-management-service
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.1
+version: 0.0.2
 kubeVersion: ">= 1.13.0"
 description: A microservice for managing access control to S3 Objects
 # A chart can be either an 'application' or a 'library' chart.

--- a/charts/coms/templates/NOTES.txt
+++ b/charts/coms/templates/NOTES.txt
@@ -1,4 +1,6 @@
-1. Get the application URL by running these commands:
+{{- $configMapName := printf "%s-%s" (include "coms.configname" .) "config" }}
+{{- $configMap := (lookup "v1" "ConfigMap" .Release.Namespace $configMapName ) }}
+Get the application URL by running these commands:
 {{- if .Values.route.enabled }}
   http{{ if $.Values.route.tls }}s{{ end }}://{{ .Values.route.host }}{{ .Values.route.path }}
 {{- else if contains "NodePort" .Values.service.type }}
@@ -15,4 +17,8 @@
   export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
   echo "Visit http://127.0.0.1:8080 to use your application"
   kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+{{- end }}
+{{- if not $configMap }}
+
+Make sure that ConfigMap "{{ $configMapName }}" is defined in the namespace; the deployment will fail to run without it!
 {{- end }}

--- a/charts/coms/templates/configmap.yaml
+++ b/charts/coms/templates/configmap.yaml
@@ -1,4 +1,5 @@
-{{- if .Values.config.enabled -}}
+{{- if .Values.config.enabled }}
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/charts/coms/templates/deploymentconfig.yaml
+++ b/charts/coms/templates/deploymentconfig.yaml
@@ -24,7 +24,7 @@ spec:
       {{- toYaml .Values.resources | nindent 6 }}
     rollingParams:
       timeoutSeconds: 600
-      {{- if .Values.config.configMap.DB_ENABLED }}
+      {{- if or .Values.patroni.enabled .Values.config.configMap.DB_ENABLED }}
       pre:
         failurePolicy: {{ .Values.failurePolicy }}
         execNewPod:
@@ -98,7 +98,7 @@ spec:
           env:
             - name: NODE_ENV
               value: production
-            {{- if .Values.config.configMap.BASICAUTH_ENABLED }}
+            {{- if or .Values.features.basicAuth .Values.config.configMap.BASICAUTH_ENABLED }}
             - name: BASICAUTH_USERNAME
               valueFrom:
                 secretKeyRef:
@@ -110,7 +110,7 @@ spec:
                   key: password
                   name: {{ include "coms.configname" . }}-basicauth
             {{- end }}
-            {{- if .Values.config.configMap.DB_ENABLED }}
+            {{- if or .Values.patroni.enabled .Values.config.configMap.DB_ENABLED }}
             - name: DB_DATABASE
               valueFrom:
                 secretKeyRef:
@@ -129,7 +129,7 @@ spec:
                   key: app-db-password
                   name: {{ include "patroni.fullname" .Subcharts.patroni }}
             {{- end }}
-            {{- if .Values.config.configMap.KC_ENABLED }}
+            {{- if or .Values.features.oidcAuth .Values.config.configMap.KC_ENABLED }}
             - name: KC_CLIENTID
               valueFrom:
                 secretKeyRef:

--- a/charts/coms/templates/hpa.yaml
+++ b/charts/coms/templates/hpa.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.autoscaling.enabled }}
+---
 apiVersion: autoscaling/v2beta2
 kind: HorizontalPodAutoscaler
 metadata:

--- a/charts/coms/templates/route.yaml
+++ b/charts/coms/templates/route.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.route.enabled -}}
+---
 apiVersion: route.openshift.io/v1
 kind: Route
 metadata:

--- a/charts/coms/templates/secret.yaml
+++ b/charts/coms/templates/secret.yaml
@@ -1,7 +1,7 @@
 {{- $password := (randAlphaNum 32) | b64enc }}
 {{- $username := (randAlphaNum 32) | b64enc }}
 
-{{- $secretName := printf "%s-%s" (include "coms.fullname" .) "basicauth" }}
+{{- $secretName := printf "%s-%s" (include "coms.configname" .) "basicauth" }}
 {{- $secret := (lookup "v1" "Secret" .Release.Namespace $secretName ) }}
 {{- if not $secret }}
 ---

--- a/charts/coms/templates/service.yaml
+++ b/charts/coms/templates/service.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: Service
 metadata:

--- a/charts/coms/templates/serviceaccount.yaml
+++ b/charts/coms/templates/serviceaccount.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.serviceAccount.enabled -}}
+---
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/coms/values.yaml
+++ b/charts/coms/values.yaml
@@ -95,31 +95,36 @@ resources:
     cpu: 50m
     memory: 128Mi
 
-# These values will be wholesale added to the configmap as is; refer to the coms
-# documentation for what each of these values mean and whether you need them defined.
-# Ensure that all values are represented explicitly as strings, as non-string values will
-# not translate over as expected into container environment variables.
-# For configuration keys named `*_ENABLED`, either leave them commented/undefined, or set them
-# to string value "true".
+features:
+  basicAuth: false
+  oidcAuth: false
+
 config:
-  enabled: true
+  # Set to true if you want to let Helm manage and overwrite your configmaps.
+  enabled: false
 
   # This should be set to true if and only if you require configmaps and secrets to be release
   # scoped. In the event you want all instances in the same namespace to share a similar
-  # configuration, this should be set to true
-  releaseScoped: true
+  # configuration, this should be set to false
+  releaseScoped: false
 
+  # These values will be wholesale added to the configmap as is; refer to the coms
+  # documentation for what each of these values mean and whether you need them defined.
+  # Ensure that all values are represented explicitly as strings, as non-string values will
+  # not translate over as expected into container environment variables.
+  # For configuration keys named `*_ENABLED`, either leave them commented/undefined, or set them
+  # to string value "true".
   configMap:
     # BASICAUTH_ENABLED: "true"
 
     # DB_ENABLED: "true"
-    # DB_PORT: "5432"
+    DB_PORT: "5432"
 
     # KC_ENABLED: "true"
-    # KC_IDENTITYKEY: ~
-    # KC_PUBLICKEY: ~
-    # KC_REALM: ~
-    # KC_SERVERURL: ~
+    KC_IDENTITYKEY: ~
+    KC_PUBLICKEY: ~
+    KC_REALM: ~
+    KC_SERVERURL: ~
 
     OBJECTSTORAGE_BUCKET: ~
     OBJECTSTORAGE_TEMP_EXPIRESIN: "300"
@@ -140,7 +145,7 @@ objectStorageSecretOverride: ~
 # Patroni subchart configuration overrides
 patroni:
   # Controls whether to enable managing a Patroni db dependency as a part of the helm release
-  enabled: true
+  enabled: false
 
   # replicaCount: 3
   # resources: {}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

<!-- Describe your changes in detail -->
This allows users to deploy the helm chart without having to also directly
specify the configmap values all the time in the values section. Also
contains a slew of typo fixes and adds the ability to choose feature
toggles.

<!-- Why is this change required? What problem does it solve? -->
We need to be able to support out-of-band configmap management; this change permits that to happen.
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->