### PR TITLE
Helm: Force basicAuth secrets to always be release scoped

### DIFF
--- a/charts/coms/Chart.yaml
+++ b/charts/coms/Chart.yaml
@@ -3,7 +3,7 @@ name: common-object-management-service
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.3
+version: 0.0.4
 kubeVersion: ">= 1.13.0"
 description: A microservice for managing access control to S3 Objects
 # A chart can be either an 'application' or a 'library' chart.

--- a/charts/coms/templates/configmap.yaml
+++ b/charts/coms/templates/configmap.yaml
@@ -4,14 +4,9 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "coms.configname" . }}-config
-  labels:
-    {{- include "coms.labels" . | nindent 4 }}
-  {{- with .Values.route.annotations }}
+  {{- if not .Values.config.releaseScoped }}
   annotations:
-    {{- if not .Values.config.releaseScoped }}
     "helm.sh/resource-policy": keep
-    {{- end }}
-    {{- toYaml . | nindent 4 }}
   {{- end }}
 data: {{ toYaml .Values.config.configMap | nindent 2 }}
 {{- end }}

--- a/charts/coms/templates/secret.yaml
+++ b/charts/coms/templates/secret.yaml
@@ -1,7 +1,7 @@
 {{- $password := (randAlphaNum 32) | b64enc }}
 {{- $username := (randAlphaNum 32) | b64enc }}
 
-{{- $secretName := printf "%s-%s" (include "coms.configname" .) "basicauth" }}
+{{- $secretName := printf "%s-%s" (include "coms.fullname" .) "basicauth" }}
 {{- $secret := (lookup "v1" "Secret" .Release.Namespace $secretName ) }}
 {{- if not $secret }}
 ---


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

<!-- Describe your changes in detail -->
Secret generation should not be shared between releases as that violates
general Helm practices. As the configmap can potentially be shared, we
need to ensure the resource-policy keep annotation appears when it is the
non-release scoped variant.
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->