### PR TITLE
Implement Tagging/TagSet Search Functionality

### DIFF
--- a/app/src/components/utils.js
+++ b/app/src/components/utils.js
@@ -177,8 +177,8 @@ const utils = {
    * @function getKeyValue
    * Transforms array of {<key>:<value>} objects to {key: <key>, value: <value>}
    * @param {any}
-   * @param {object} input of key value tuples like `<key>:<value>`
-   * @returns {object[]} array of objects like `{key: <key>, value: <value>}`
+   * @param {object[]} input Array of key value tuples like `<key>:<value>`
+   * @returns {object[]} Array of objects like `{key: <key>, value: <value>}`
    */
   getKeyValue(input) {
     return Object.entries(input).map(([k, v]) => ({ key: k, value: v }));
@@ -245,20 +245,20 @@ const utils = {
   },
 
   /**
-   * @function toLowerKeys converts all key names for all objects in an array to lowercase
-   * @param {object[]} Array of tag objects (eg: [{Key: k1, Value: V1}])
+   * @function toLowerKeys
+   * Converts all key names for all objects in an array to lowercase
+   * @param {object[]} arr Array of tag objects (eg: [{Key: k1, Value: V1}])
    * @returns {object[]} Array of objects (eg: [{key: k1, value: V1}])
    */
   toLowerKeys(arr) {
-    const result = arr.map(obj => {
-      const entries = Object.entries(obj);
+    if (!arr) return [];
+    return arr.map(obj => {
       return Object.fromEntries(
-        entries.map(([key, value]) => {
+        Object.entries(obj).map(([key, value]) => {
           return [key.toLowerCase(), value];
         }),
       );
     });
-    return result;
   },
 };
 

--- a/app/src/controllers/object.js
+++ b/app/src/controllers/object.js
@@ -108,7 +108,7 @@ const controller = {
             await versionService.update({ ...data, id: objId }, userId, trx);
 
           // add metadata to version in DB
-          await metadataService.addMetadata(version.id, data.metadata, userId, trx);
+          await metadataService.updateMetadata(version.id, data.metadata, userId, trx);
         });
 
         controller._setS3Headers(s3Response, res);
@@ -157,7 +157,7 @@ const controller = {
         // Add tags to version in DB
         await utils.trxWrapper(async (trx) => {
           const version = await versionService.get(data.versionId, objId, trx);
-          await tagService.addTags(version.id, toLowerKeys(data.tags), userId, trx);
+          await tagService.updateTags(version.id, toLowerKeys(data.tags), userId, trx);
         });
 
         controller._setS3Headers(response, res);
@@ -210,10 +210,10 @@ const controller = {
           const versions = await versionService.create(data, userId, trx);
 
           // add metadata to version in DB
-          if (data.metadata && Object.keys(data.metadata).length) await metadataService.addMetadata(versions.id, data.metadata, userId, trx);
+          if (data.metadata && Object.keys(data.metadata).length) await metadataService.updateMetadata(versions.id, data.metadata, userId, trx);
 
           // add tags to version in DB
-          if (data.tags && Object.keys(data.tags).length) await tagService.addTags(versions.id, getKeyValue(data.tags), userId, trx);
+          if (data.tags && Object.keys(data.tags).length) await tagService.updateTags(versions.id, getKeyValue(data.tags), userId, trx);
 
           return object;
         });
@@ -300,7 +300,7 @@ const controller = {
           await versionService.update({ ...data, id: objId }, userId, trx);
 
         // add metadata to version in DB
-        await metadataService.addMetadata(version.id, data.metadata, userId, trx);
+        await metadataService.updateMetadata(version.id, data.metadata, userId, trx);
       });
 
       controller._setS3Headers(s3Response, res);
@@ -398,14 +398,14 @@ const controller = {
       let response;
       if (newTags) {
         response = await storageService.putObjectTagging(data);
-      }
-      else {
+      } else {
         response = await storageService.deleteObjectTagging(data);
       }
+
       // update tags for version in DB
       await utils.trxWrapper(async (trx) => {
         const version = await versionService.get(data.versionId, objId, trx);
-        await tagService.addTags(version.id, toLowerKeys(data.tags), userId, trx);
+        await tagService.updateTags(version.id, toLowerKeys(data.tags), userId, trx);
       });
 
       controller._setS3Headers(response, res);
@@ -554,7 +554,7 @@ const controller = {
             await versionService.update({ ...data, id: objId }, userId, trx);
 
           // add metadata
-          await metadataService.addMetadata(version.id, data.metadata, userId, trx);
+          await metadataService.updateMetadata(version.id, data.metadata, userId, trx);
         });
 
         controller._setS3Headers(s3Response, res);
@@ -598,7 +598,7 @@ const controller = {
         // update tags on version in DB
         await utils.trxWrapper(async (trx) => {
           const version = await versionService.get(data.versionId, objId, trx);
-          await tagService.addTags(version.id, toLowerKeys(data.tags), userId, trx);
+          await tagService.updateTags(version.id, toLowerKeys(data.tags), userId, trx);
         });
 
         controller._setS3Headers(response, res);
@@ -724,10 +724,10 @@ const controller = {
           }
 
           // add metadata to version in DB
-          if (data.metadata && Object.keys(data.metadata).length) await metadataService.addMetadata(version.id, data.metadata, userId, trx);
+          if (data.metadata && Object.keys(data.metadata).length) await metadataService.updateMetadata(version.id, data.metadata, userId, trx);
 
           // add tags to version in DB
-          if (data.tags && Object.keys(data.tags).length) await tagService.addTags(version.id, getKeyValue(data.tags), userId, trx);
+          if (data.tags && Object.keys(data.tags).length) await tagService.updateTags(version.id, getKeyValue(data.tags), userId, trx);
 
           return object;
         });

--- a/app/src/controllers/object.js
+++ b/app/src/controllers/object.js
@@ -617,18 +617,19 @@ const controller = {
    */
   async searchObjects(req, res, next) {
     // TODO: Handle no database scenarios via S3 ListObjectsCommand?
-    // TODO: Consider tagging query parameter design here
     // TODO: Consider support for filtering by set of permissions?
     // TODO: handle additional parameters. Eg: deleteMarker, latest
     try {
       const objIds = mixedQueryToArray(req.query.objId);
       const metadata = getMetadata(req.headers);
+      const tagging = req.query.tagging;
       const params = {
         id: objIds ? objIds.map(id => addDashesToUuid(id)) : objIds,
         name: req.query.name,
         path: req.query.path,
         mimeType: req.query.mimeType,
         metadata: metadata && Object.keys(metadata).length ? metadata : undefined,
+        tag: tagging && Object.keys(tagging).length ? tagging : undefined,
         public: isTruthy(req.query.public),
         active: isTruthy(req.query.active)
       };

--- a/app/src/db/models/tables/objectModel.js
+++ b/app/src/db/models/tables/objectModel.js
@@ -70,24 +70,36 @@ class ObjectModel extends Timestamps(Model) {
             });
         }
       },
-      filterMetadata(query, name, metadata) {
+      filterMetadataTag(query, value) {
         const subqueries = [];
 
-        if (name) {
-          subqueries.push(Version.query()
+        if (value.name) {
+          const q = Version.query()
             .select('version.id')
             .joinRelated('metadata')
             .where('metadata.key', 'name')
-            .where('metadata.value', 'ilike', `%${name}%`));
+            .where('metadata.value', 'ilike', `%${value.name}%`);
+          subqueries.push(q);
         }
 
-        if (metadata && Object.keys(metadata).length) {
-          Object.entries(metadata).forEach(([key, val]) => {
+        if (value.metadata && Object.keys(value.metadata).length) {
+          Object.entries(value.metadata).forEach(([key, val]) => {
             const q = Version.query()
               .select('version.id')
               .joinRelated('metadata')
               .where('metadata.key', key);
             if (val.length) q.where('metadata.value', val);
+            subqueries.push(q);
+          });
+        }
+
+        if (value.tag && Object.keys(value.tag).length) {
+          Object.entries(value.tag).forEach(([key, val]) => {
+            const q = Version.query()
+              .select('version.id')
+              .joinRelated('tag')
+              .where('tag.key', key);
+            if (val.length) q.where('tag.value', val);
             subqueries.push(q);
           });
         }

--- a/app/src/docs/v1.api-spec.yaml
+++ b/app/src/docs/v1.api-spec.yaml
@@ -447,7 +447,7 @@ paths:
     patch:
       summary: Adds tags to an object
       description: >-
-        Adds specified tagsets to the object. Multiple Key/Value tagset pairs
+        Adds a specified set of tags to the object. Multiple Key/Value pairs
         can be provided in the query.
       operationId: addTagging
       tags:
@@ -470,8 +470,8 @@ paths:
     put:
       summary: Replaces tags of an object
       description: >-
-        Replace the existing tags of an object with the given tagsets. Multiple
-        Key/Value tagset pairs can be provided in the query.
+        Replace the existing tag-set of an object with the set of given tags.
+        Multiple Key/Value pairs can be provided in the query.
       operationId: replaceTagging
       tags:
         - Object Tagging
@@ -493,9 +493,9 @@ paths:
     delete:
       summary: Delete tags of an object.
       description: >-
-        Removes the specified tagsets from the object. Multiple Key/Value
-        tagset pairs can be provided in the query. All tagsets will be
-        removed from the object if no tagsets are specified.
+        Removes the specified set of tags from the object. Multiple Key/Value
+        pairs can be provided in the query. All tags in the tag-set will be
+        removed from the object if no tags are specified.
       operationId: deleteTagging
       tags:
         - Object Tagging
@@ -931,11 +931,12 @@ components:
         example: true
     Query-TagSet:
       in: query
-      name: tagging[*]
+      name: tagset[*]
       description: >-
-        Tags to add to the object, defined as Key/Value TagSet. The query should
-        be formatted in deepObject style notation, where multiple TagSets would
-        be encoded something similar to `tagging[x]=a&tagging[y]=b`.
+        Tags to add to the object, defined as a Key/Value tag. The query must
+        be formatted in deepObject style notation, where a tag-set made out of
+        multiple tags would be encoded something similar to
+        `tagset[x]=a&tagset[y]=b`.
       schema:
         $ref: '#/components/schemas/S3-TagSet'
       style: deepObject
@@ -1398,11 +1399,11 @@ components:
       properties:
         key:
           type: string
-          description: The TagSet key
+          description: The tag key
           example: x
         value:
           type: string
-          description: The TagSet value
+          description: The tag value
           example: a
     S3-Version:
       type: object

--- a/app/src/docs/v1.api-spec.yaml
+++ b/app/src/docs/v1.api-spec.yaml
@@ -30,7 +30,7 @@ tags:
     externalDocs:
       url: >-
         https://github.com/bcgov/common-object-management-service/wiki/Endpoint-Notes#metadata
-  - name: Object Tag
+  - name: Object Tagging
     description: Operations directly influencing the Tags of an S3 Object.
     externalDocs:
       url: >-
@@ -63,7 +63,7 @@ paths:
         - Object
       parameters:
         - $ref: '#/components/parameters/Header-Metadata'
-        - $ref: '#/components/parameters/Query-Tag'
+        - $ref: '#/components/parameters/Query-TagSet'
       requestBody:
         description: Form-data containing files
         required: true
@@ -132,6 +132,7 @@ paths:
         - $ref: '#/components/parameters/Query-Public'
         - $ref: '#/components/parameters/Query-MimeType'
         - $ref: '#/components/parameters/Query-Name'
+        - $ref: '#/components/parameters/Query-TagSet'
       responses:
         '201':
           description: Returns and array of objects
@@ -245,9 +246,9 @@ paths:
       tags:
         - Object
       parameters:
-        - $ref: '#/components/parameters/Path-ObjectId'
-        - $ref: '#/components/parameters/Query-Tag'
         - $ref: '#/components/parameters/Header-Metadata'
+        - $ref: '#/components/parameters/Path-ObjectId'
+        - $ref: '#/components/parameters/Query-TagSet'
       requestBody:
         description: Form-data containing files
         required: true
@@ -442,18 +443,18 @@ paths:
           $ref: '#/components/responses/Forbidden'
         default:
           $ref: '#/components/responses/Error'
-  /object/{objId}/tags:
+  /object/{objId}/tagging:
     patch:
       summary: Adds tags to an object
       description: >-
-        Adds the given tagset to the object. Multiple comma separated Key/Value
-        pairs can be provided in the query.
+        Adds specified tagsets to the object. Multiple Key/Value tagset pairs
+        can be provided in the query.
       operationId: addTags
       tags:
-        - Object Tag
+        - Object Tagging
       parameters:
         - $ref: '#/components/parameters/Path-ObjectId'
-        - $ref: '#/components/parameters/Query-Tag'
+        - $ref: '#/components/parameters/Query-TagSet'
         - $ref: '#/components/parameters/Query-VersionId'
       responses:
         '204':
@@ -469,14 +470,15 @@ paths:
     put:
       summary: Replaces tags of an object
       description: >-
-        Replace the existing tags of an object with the given tagset. Multiple
-        comma separated Key/Value pairs can be provided in the query.
+        Replace the existing tags of an object with the given tagsets. Multiple
+        Key/Value tagset pairs can be provided in the query. All tagsets will be
+        removed from the object if no tagsets are specified.
       operationId: replaceTags
       tags:
-        - Object Tag
+        - Object Tagging
       parameters:
         - $ref: '#/components/parameters/Path-ObjectId'
-        - $ref: '#/components/parameters/Query-Tag'
+        - $ref: '#/components/parameters/Query-TagSet'
         - $ref: '#/components/parameters/Query-VersionId'
       responses:
         '204':
@@ -492,15 +494,15 @@ paths:
     delete:
       summary: Delete tags of an object.
       description: >-
-        Removes the given tags from the object. Multiple comma separated keys
-        can be provided in the query. If no keys are given then all keys will be
-        removed.
+        Removes the specified tagsets from the object. Multiple Key/Value
+        tagset pairs can be provided in the query. All tagsets will be
+        removed from the object if no tagsets are specified.
       operationId: deleteTags
       tags:
-        - Object Tag
+        - Object Tagging
       parameters:
         - $ref: '#/components/parameters/Path-ObjectId'
-        - $ref: '#/components/parameters/Query-Keys'
+        - $ref: '#/components/parameters/Query-TagSet'
         - $ref: '#/components/parameters/Query-VersionId'
       responses:
         '204':
@@ -859,13 +861,6 @@ components:
             items:
               type: string
               example: idir
-    Query-Keys:
-      in: query
-      name: keys
-      description: String of keys to remove
-      schema:
-        type: string
-        example: Foo,Bar
     Query-LastName:
       in: query
       name: lastName
@@ -935,13 +930,17 @@ components:
       schema:
         type: boolean
         example: true
-    Query-Tag:
+    Query-TagSet:
       in: query
-      name: anyKey
-      description: Tags to add to the object, defined as Key/Value pairs
+      name: tagging[*]
+      description: >-
+        Tags to add to the object, defined as Key/Value TagSet. The query should
+        be formatted in deepObject style notation, where multiple TagSets would
+        be encoded something similar to `tagging[x]=a&tagging[y]=b`.
       schema:
-        type: string
-        example: anyValue
+        $ref: '#/components/schemas/S3-TagSet'
+      style: deepObject
+      explode: true
     Query-UserSearch:
       in: query
       name: search
@@ -1393,6 +1392,19 @@ components:
           type: string
           description: a version identifier created in S3
           example: 1647462569641
+    S3-TagSet:
+      type: object
+      required:
+        - key
+      properties:
+        key:
+          type: string
+          description: The TagSet key
+          example: x
+        value:
+          type: string
+          description: The TagSet value
+          example: a
     S3-Version:
       type: object
       required:

--- a/app/src/docs/v1.api-spec.yaml
+++ b/app/src/docs/v1.api-spec.yaml
@@ -449,7 +449,7 @@ paths:
       description: >-
         Adds specified tagsets to the object. Multiple Key/Value tagset pairs
         can be provided in the query.
-      operationId: addTags
+      operationId: addTagging
       tags:
         - Object Tagging
       parameters:
@@ -471,9 +471,8 @@ paths:
       summary: Replaces tags of an object
       description: >-
         Replace the existing tags of an object with the given tagsets. Multiple
-        Key/Value tagset pairs can be provided in the query. All tagsets will be
-        removed from the object if no tagsets are specified.
-      operationId: replaceTags
+        Key/Value tagset pairs can be provided in the query.
+      operationId: replaceTagging
       tags:
         - Object Tagging
       parameters:
@@ -497,7 +496,7 @@ paths:
         Removes the specified tagsets from the object. Multiple Key/Value
         tagset pairs can be provided in the query. All tagsets will be
         removed from the object if no tagsets are specified.
-      operationId: deleteTags
+      operationId: deleteTagging
       tags:
         - Object Tagging
       parameters:

--- a/app/src/routes/v1/object.js
+++ b/app/src/routes/v1/object.js
@@ -66,17 +66,17 @@ routes.delete('/:objId/metadata', currentObject, requireSomeAuth, (req, res, nex
 });
 
 /** Add tags to an object */
-routes.patch('/:objId/tag', currentObject, requireSomeAuth, (req, res, next) => {
+routes.patch('/:objId/tagging', currentObject, requireSomeAuth, (req, res, next) => {
   objectController.addTags(req, res, next);
 });
 
 /** Add tags to an object */
-routes.put('/:objId/tag', currentObject, requireSomeAuth, (req, res, next) => {
+routes.put('/:objId/tagging', currentObject, requireSomeAuth, (req, res, next) => {
   objectController.replaceTags(req, res, next);
 });
 
 /** Add tags to an object */
-routes.delete('/:objId/tag', currentObject, requireSomeAuth, (req, res, next) => {
+routes.delete('/:objId/tagging', currentObject, requireSomeAuth, (req, res, next) => {
   objectController.deleteTags(req, res, next);
 });
 

--- a/app/src/services/metadata.js
+++ b/app/src/services/metadata.js
@@ -8,8 +8,8 @@ const { getKeyValue } = require('../components/utils');
 const service = {
 
   /**
-   * @function addMetadata
-   * Add given Metadata and relate to a given version in database
+   * @function updateMetadata
+   * Updates metadata and relates them to the associated version
    * Un-relates any existing metadata for this version
    * @param {string} versionId The uuid id column from version table
    * @param {object} metadata Incoming object with `<key>:<value>` metadata to add for this version
@@ -18,7 +18,7 @@ const service = {
    * @returns {Promise<object>} The result of running the insert operation
    * @throws The error encountered upon db transaction failure
    */
-  addMetadata: async (versionId, metadata, currentUserId = SYSTEM_USER, etrx = undefined) => {
+  updateMetadata: async (versionId, metadata, currentUserId = SYSTEM_USER, etrx = undefined) => {
     let trx;
     try {
       trx = etrx ? etrx : await Metadata.startTransaction();

--- a/app/src/services/object.js
+++ b/app/src/services/object.js
@@ -87,6 +87,7 @@ const service = {
    * @param {string} [params.mimeType] Optional mimeType string to match on
    * @param {string} [params.name] Optional metadata name string to match on
    * @param {object} [params.metadata] Optional object of metadata key/value pairs
+   * @param {object} [params.tag] Optional object of tag key/value pairs
    * @returns {Promise<object[]>} The result of running the find operation
    */
   searchObjects: (params) => {
@@ -98,7 +99,11 @@ const service = {
       .modify('filterActive', params.active)
       .modify('filterUserId', params.userId)
       .modify('filterMimeType', params.mimeType)
-      .modify('filterMetadata', params.name, params.metadata)
+      .modify('filterMetadataTag', {
+        name: params.name,
+        metadata: params.metadata,
+        tag: params.tag
+      })
       .then(result => result.map(row => {
         // eslint-disable-next-line no-unused-vars
         const { objectPermission, version, ...object } = row;

--- a/app/src/services/storage.js
+++ b/app/src/services/storage.js
@@ -278,6 +278,7 @@ const objectStorageService = {
       }).join('&');
     }
 
+    // TODO: Consider refactoring to use Upload instead from @aws-sdk/lib-storage
     return this._s3Client.send(new PutObjectCommand(params));
   },
 

--- a/app/src/services/version.js
+++ b/app/src/services/version.js
@@ -209,7 +209,7 @@ const service = {
         .first()
         .returning('id');
 
-      if (data.metadata) await metadataService.addMetadata(response.id, data.metadata, data.userId, trx);
+      if (data.metadata) await metadataService.updateMetadata(response.id, data.metadata, data.userId, trx);
 
       if (!etrx) await trx.commit();
       return Promise.resolve(response);

--- a/app/src/validators/object.js
+++ b/app/src/validators/object.js
@@ -35,11 +35,15 @@ const schema = {
   },
 
   searchObjects: {
+    headers: Joi.object()
+      .pattern(/^x-amz-meta-.{1,255}$/i, Joi.string().max(255))
+      .unknown(),
     query: Joi.object({
       objId: scheme.guid,
       name: Joi.string(),
       path: Joi.string().max(1024),
       mimeType: Joi.string().max(255),
+      tagging: Joi.object().pattern(/^.{1,128}$/, Joi.string().max(255)),
       public: type.truthy,
       active: type.truthy
     })

--- a/app/src/validators/object.js
+++ b/app/src/validators/object.js
@@ -36,14 +36,14 @@ const schema = {
 
   searchObjects: {
     headers: Joi.object()
-      .pattern(/^x-amz-meta-.{1,255}$/i, Joi.string().max(255))
+      .pattern(/^x-amz-meta-.{1,255}$/i, Joi.string().min(0).max(255))
       .unknown(),
     query: Joi.object({
       objId: scheme.guid,
       name: Joi.string(),
       path: Joi.string().max(1024),
       mimeType: Joi.string().max(255),
-      tagging: Joi.object().pattern(/^.{1,128}$/, Joi.string().max(255)),
+      tagset: Joi.object().pattern(/^.{1,128}$/, Joi.string().min(0).max(255)),
       public: type.truthy,
       active: type.truthy
     })

--- a/app/tests/unit/controllers/object.spec.js
+++ b/app/tests/unit/controllers/object.spec.js
@@ -139,10 +139,12 @@ describe('addTags', () => {
     // request object
     const req = {
       params: { objId: 'xyz-789' },
-      query: { a: '1', b: '2', c: '3', d: '4', e: '5', f: '6', g: '7', h: '8', i: '9', j: '10', k: '11' }
+      query: {
+        tagset: { a: '1', b: '2', c: '3', d: '4', e: '5', f: '6', g: '7', h: '8', i: '9', j: '10', k: '11' }
+      }
     };
 
-    storageGetObjectTaggingSpy.mockReturnValue(getObjectTaggingResponse);
+    storageGetObjectTaggingSpy.mockResolvedValue(getObjectTaggingResponse);
     await controller.addTags(req, res, next);
     expect(res.status).toHaveBeenCalledWith(422);
   });
@@ -154,11 +156,13 @@ describe('addTags', () => {
     // request object
     const req = {
       params: { objId: 'xyz-789' },
-      query: { foo: 'bar', baz: 'bam' }
+      query: {
+        tagset: { foo: 'bar', baz: 'bam' }
+      }
     };
 
-    storageGetObjectTaggingSpy.mockReturnValue(getObjectTaggingResponse);
-    storagePutObjectTaggingSpy.mockReturnValue({});
+    storageGetObjectTaggingSpy.mockResolvedValue(getObjectTaggingResponse);
+    storagePutObjectTaggingSpy.mockResolvedValue({});
 
     await controller.addTags(req, res, next);
 
@@ -182,11 +186,13 @@ describe('addTags', () => {
     // request object
     const req = {
       params: { objId: 'xyz-789' },
-      query: { foo: 'bar', baz: 'bam' }
+      query: {
+        tagset: { foo: 'bar', baz: 'bam' }
+      }
     };
 
-    storageGetObjectTaggingSpy.mockReturnValue(getObjectTaggingResponse);
-    storagePutObjectTaggingSpy.mockReturnValue({});
+    storageGetObjectTaggingSpy.mockResolvedValue(getObjectTaggingResponse);
+    storagePutObjectTaggingSpy.mockResolvedValue({});
 
     await controller.addTags(req, res, next);
 
@@ -439,7 +445,9 @@ describe('deleteTags', () => {
     // request object
     const req = {
       params: { objId: 'xyz-789' },
-      query: { keys: 'foo, baz' }
+      query: {
+        tagset: { foo: '', baz: '' }
+      }
     };
 
     storageGetObjectTaggingSpy.mockReturnValue(getObjectTaggingResponse);
@@ -556,72 +564,74 @@ describe('replaceMetadata', () => {
       versionId: undefined
     });
   });
+});
 
-  describe('replaceTags', () => {
-    afterEach(() => {
-      jest.resetAllMocks();
-    });
+describe('replaceTags', () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
 
-    // mock service calls
-    const storageGetObjectTaggingSpy = jest.spyOn(storageService, 'getObjectTagging');
-    const storagePutObjectTaggingSpy = jest.spyOn(storageService, 'putObjectTagging');
+  // mock service calls
+  const storageGetObjectTaggingSpy = jest.spyOn(storageService, 'getObjectTagging');
+  const storagePutObjectTaggingSpy = jest.spyOn(storageService, 'putObjectTagging');
 
-    const next = jest.fn();
+  const next = jest.fn();
 
-    it('responds 422 when no query keys are present', async () => {
-      // response from S3
-      const getObjectTaggingResponse = {};
+  it('responds 422 when no query keys are present', async () => {
+    // response from S3
+    const getObjectTaggingResponse = {};
 
-      // request object
-      const req = {
-        params: { objId: 'xyz-789' },
-        query: {}
-      };
+    // request object
+    const req = {
+      params: { objId: 'xyz-789' },
+      query: {}
+    };
 
-      storageGetObjectTaggingSpy.mockReturnValue(getObjectTaggingResponse);
-      await controller.replaceTags(req, res, next);
-      expect(res.status).toHaveBeenCalledWith(422);
-    });
+    storageGetObjectTaggingSpy.mockReturnValue(getObjectTaggingResponse);
+    await controller.replaceTags(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(422);
+  });
 
-    it('responds 422 when more than 10 keys', async () => {
-      // response from S3
-      const getObjectTaggingResponse = {};
+  it('responds 422 when more than 10 keys', async () => {
+    // response from S3
+    const getObjectTaggingResponse = {};
 
-      // request object
-      const req = {
-        params: { objId: 'xyz-789' },
-        query: { a: '1', b: '2', c: '3', d: '4', e: '5', f: '6', g: '7', h: '8', i: '9', j: '10', k: '11' }
-      };
+    // request object
+    const req = {
+      params: { objId: 'xyz-789' },
+      query: { a: '1', b: '2', c: '3', d: '4', e: '5', f: '6', g: '7', h: '8', i: '9', j: '10', k: '11' }
+    };
 
-      storageGetObjectTaggingSpy.mockReturnValue(getObjectTaggingResponse);
-      await controller.replaceTags(req, res, next);
-      expect(res.status).toHaveBeenCalledWith(422);
-    });
+    storageGetObjectTaggingSpy.mockReturnValue(getObjectTaggingResponse);
+    await controller.replaceTags(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(422);
+  });
 
-    it('should add the new tags', async () => {
-      // response from S3
-      const getObjectTaggingResponse = {};
+  it('should add the new tags', async () => {
+    // response from S3
+    const getObjectTaggingResponse = {};
 
-      // request object
-      const req = {
-        params: { objId: 'xyz-789' },
-        query: { foo: 'bar', baz: 'bam' }
-      };
+    // request object
+    const req = {
+      params: { objId: 'xyz-789' },
+      query: {
+        tagset: { foo: 'bar', baz: 'bam' }
+      }
+    };
 
-      storageGetObjectTaggingSpy.mockReturnValue(getObjectTaggingResponse);
-      storagePutObjectTaggingSpy.mockReturnValue({});
+    storageGetObjectTaggingSpy.mockReturnValue(getObjectTaggingResponse);
+    storagePutObjectTaggingSpy.mockReturnValue({});
 
-      await controller.replaceTags(req, res, next);
+    await controller.replaceTags(req, res, next);
 
-      expect(res.status).toHaveBeenCalledWith(204);
-      expect(storagePutObjectTaggingSpy).toHaveBeenCalledWith({
-        filePath: 'xyz-789',
-        tags: [
-          { Key: 'foo', Value: 'bar' },
-          { Key: 'baz', Value: 'bam' },
-        ],
-        versionId: undefined
-      });
+    expect(res.status).toHaveBeenCalledWith(204);
+    expect(storagePutObjectTaggingSpy).toHaveBeenCalledWith({
+      filePath: 'xyz-789',
+      tags: [
+        { Key: 'foo', Value: 'bar' },
+        { Key: 'baz', Value: 'bam' },
+      ],
+      versionId: undefined
     });
   });
 });

--- a/app/tests/unit/controllers/object.spec.js
+++ b/app/tests/unit/controllers/object.spec.js
@@ -30,7 +30,7 @@ describe('addMetadata', () => {
   const storageHeadObjectSpy = jest.spyOn(storageService, 'headObject');
   const storageCopyObjectSpy = jest.spyOn(storageService, 'copyObject');
   const versionCopySpy = jest.spyOn(versionService, 'copy');
-  const metadataAddMetadataSpy = jest.spyOn(metadataService, 'addMetadata');
+  const metadataUpdateMetadataSpy = jest.spyOn(metadataService, 'updateMetadata');
   const trxWrapperSpy = jest.spyOn(utils, 'trxWrapper');
   const setHeadersSpy = jest.spyOn(controller, '_setS3Headers');
 
@@ -82,7 +82,7 @@ describe('addMetadata', () => {
     storageCopyObjectSpy.mockResolvedValue(GoodResponse);
     trxWrapperSpy.mockImplementation(callback => callback({}));
     versionCopySpy.mockReturnValue({id: '5dad1ec9-d3c0-4b0f-8ead-cb4d9fa98987'});
-    metadataAddMetadataSpy.mockReturnValue({});
+    metadataUpdateMetadataSpy.mockReturnValue({});
     setHeadersSpy.mockImplementation(x => x);
 
     await controller.addMetadata(req, res, next);
@@ -101,7 +101,7 @@ describe('addMetadata', () => {
 
     expect(trxWrapperSpy).toHaveBeenCalledTimes(1);
     expect(versionCopySpy).toHaveBeenCalledTimes(1);
-    expect(metadataAddMetadataSpy).toHaveBeenCalledTimes(1);
+    expect(metadataUpdateMetadataSpy).toHaveBeenCalledTimes(1);
     expect(res.status).toHaveBeenCalledWith(204);
   });
 });
@@ -127,7 +127,7 @@ describe('addTags', () => {
       query: {}
     };
 
-    storageGetObjectTaggingSpy.mockReturnValue(getObjectTaggingResponse);
+    storageGetObjectTaggingSpy.mockResolvedValue(getObjectTaggingResponse);
     await controller.addTags(req, res, next);
     expect(res.status).toHaveBeenCalledWith(422);
   });

--- a/app/tests/unit/validators/object.spec.js
+++ b/app/tests/unit/validators/object.spec.js
@@ -108,6 +108,41 @@ describe('readObject', () => {
 
 describe('searchObjects', () => {
 
+  describe('headers', () => {
+    const headers = schema.searchObjects.headers.describe();
+
+    it('is an object', () => {
+      expect(headers).toBeTruthy();
+      expect(headers.type).toEqual('object');
+    });
+
+    it('permits other attributes', () => {
+      expect(headers.flags).toBeTruthy();
+      expect(headers.flags).toEqual(expect.objectContaining({
+        unknown: true
+      }));
+    });
+
+    it('enforces general metadata pattern', () => {
+      expect(headers.patterns).toEqual(expect.arrayContaining([
+        expect.objectContaining({
+          regex: '/^x-amz-meta-.{1,255}$/i',
+          rule: expect.objectContaining({
+            type: 'string',
+            rules: expect.arrayContaining([
+              expect.objectContaining({
+                name: 'max',
+                args: expect.objectContaining({
+                  limit: 255
+                })
+              })
+            ])
+          })
+        })
+      ]));
+    });
+  });
+
   describe('query', () => {
     const query = schema.searchObjects.query.describe();
 
@@ -186,6 +221,34 @@ describe('searchObjects', () => {
       it('must be less than or equal to 255 characters long', () => {
         const longStr = crypto.randomBytes(256).toString('hex');
         expect(longStr).not.toMatchSchema(Joi.string().max(255));
+      });
+    });
+
+    describe('tagging', () => {
+      const tagging = query.keys.tagging;
+
+      it('is an object', () => {
+        expect(tagging).toBeTruthy();
+        expect(tagging.type).toEqual('object');
+      });
+
+      it('enforces general tagging pattern', () => {
+        expect(tagging.patterns).toEqual(expect.arrayContaining([
+          expect.objectContaining({
+            regex: '/^.{1,128}$/',
+            rule: expect.objectContaining({
+              type: 'string',
+              rules: expect.arrayContaining([
+                expect.objectContaining({
+                  name: 'max',
+                  args: expect.objectContaining({
+                    limit: 255
+                  })
+                })
+              ])
+            })
+          })
+        ]));
       });
     });
 

--- a/app/tests/unit/validators/object.spec.js
+++ b/app/tests/unit/validators/object.spec.js
@@ -131,6 +131,12 @@ describe('searchObjects', () => {
             type: 'string',
             rules: expect.arrayContaining([
               expect.objectContaining({
+                name: 'min',
+                args: expect.objectContaining({
+                  limit: 0
+                })
+              }),
+              expect.objectContaining({
                 name: 'max',
                 args: expect.objectContaining({
                   limit: 255
@@ -224,21 +230,27 @@ describe('searchObjects', () => {
       });
     });
 
-    describe('tagging', () => {
-      const tagging = query.keys.tagging;
+    describe('tagset', () => {
+      const tagset = query.keys.tagset;
 
       it('is an object', () => {
-        expect(tagging).toBeTruthy();
-        expect(tagging.type).toEqual('object');
+        expect(tagset).toBeTruthy();
+        expect(tagset.type).toEqual('object');
       });
 
-      it('enforces general tagging pattern', () => {
-        expect(tagging.patterns).toEqual(expect.arrayContaining([
+      it('enforces general tagset pattern', () => {
+        expect(tagset.patterns).toEqual(expect.arrayContaining([
           expect.objectContaining({
             regex: '/^.{1,128}$/',
             rule: expect.objectContaining({
               type: 'string',
               rules: expect.arrayContaining([
+                expect.objectContaining({
+                  name: 'min',
+                  args: expect.objectContaining({
+                    limit: 0
+                  })
+                }),
                 expect.objectContaining({
                   name: 'max',
                   args: expect.objectContaining({


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

<!-- Describe your changes in detail -->
This PR focuses on implementing the Tagging/TagSet search capabilities. It also does a pass on consistency by implementing a breaking change to the query shape to now expect a tagset deepObject for all tag related operations. This was done in order to maximize the consistency of handling tags on COMS, regardless of the desired operation.

- Change tag subroute to tagging and accept tagset as a query parameter
- Rename addTags/addMetadata to updateTags/addMetadata
- Update OpenAPI spec with tagging operationIds
- Fix utils functions to have more defensive fallback logic
- Update createObject, updateObject and searchObject to use tagset
- Update OpenAPI spec with TagSet breaking change
- Implement tagging search support

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
[SHOWCASE-2563](https://apps.nrs.gov.bc.ca/int/jira/browse/SHOWCASE-2563)

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
New feature (non-breaking change which adds functionality)
Documentation (non-breaking change with enhancements to documentation)
Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
Validation layer is not present - is is possible to break the database with a malformed `tagset` query at this time.