### PR TITLE
Refactor general CORS behavior

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -27,14 +27,7 @@ let probeId;
 const app = express();
 app.use(compression());
 app.use(cors({
-  // Consider specifying '*' to permit any arbitrary header to be exposed to other domains
-  exposedHeaders: [
-    'ETag',
-    'x-amz-meta-name',
-    'x-amz-meta-id',
-    'x-amz-server-side-encryption',
-    'x-amz-version-id'
-  ]
+  origin: true // Set true to dynamically set Access-Control-Allow-Origin based on Origin
 }));
 app.use(express.json({ limit: config.get('server.bodyLimit') }));
 app.use(express.urlencoded({ extended: true }));

--- a/app/src/routes/v1/object.js
+++ b/app/src/routes/v1/object.js
@@ -32,6 +32,7 @@ routes.get('/:objId', objectValidator.readObject, currentObject, hasPermission(P
 
 /** Updates an object */
 routes.post('/:objId', currentObject, hasPermission(Permissions.UPDATE), (req, res, next) => {
+  // TODO: Add validation to reject unexpected query parameters
   objectController.updateObject(req, res, next);
 });
 

--- a/app/tests/unit/controllers/object.spec.js
+++ b/app/tests/unit/controllers/object.spec.js
@@ -32,7 +32,7 @@ describe('addMetadata', () => {
   const versionCopySpy = jest.spyOn(versionService, 'copy');
   const metadataUpdateMetadataSpy = jest.spyOn(metadataService, 'updateMetadata');
   const trxWrapperSpy = jest.spyOn(utils, 'trxWrapper');
-  const setHeadersSpy = jest.spyOn(controller, '_setS3Headers');
+  const setHeadersSpy = jest.spyOn(controller, '_processS3Headers');
 
   const next = jest.fn();
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

<!-- Describe your changes in detail -->
This commit focuses on making the CORS headers more precise with origin
management, refactoring _setS3Headers to _processS3Headers, as well as
reordering CORS library execution to ensure the proper headers are set on
only the GET /object and HEAD /object endpoints.
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
[SHOWCASE-2761](https://apps.nrs.gov.bc.ca/int/jira/browse/SHOWCASE-2761)

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
New feature (non-breaking change which adds functionality)
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
Going forwards, those endpoints will emit a Vary: Origin header response. Clients that need to work through CORS restrictions must now emit an Origin header as a part of their request as per RFC 6454 in order to get an Access-Control-Allow-Origin that is tailored to their origin.