### PR TITLE
Allow signedUrl to be emitted as content

### DIFF
--- a/app/src/components/constants.js
+++ b/app/src/components/constants.js
@@ -21,8 +21,17 @@ module.exports = Object.freeze({
     NONE: 'NONE'
   },
 
+  /** Download mode behavior overrides */
+  DownloadMode: {
+    /** Proxies payload data through COMS */
+    PROXY: 'proxy',
+    /** Returns only a pre-signed S3 url */
+    URL: 'url'
+  },
+
   /** Maximum Content Length supported by S3 CopyObjectCommand */
   MAXCOPYOBJECTLENGTH: 5 * 1024 * 1024 * 1024,
+
   /** Default maximum number of keys to list. S3 default cap is 1000*/
   MAXKEYS: (2 ** 31) - 1,
 
@@ -54,5 +63,5 @@ module.exports = Object.freeze({
     DELETE: 'DELETE',
     /** Grants object permission management */
     MANAGE: 'MANAGE'
-  },
+  }
 });

--- a/app/src/controllers/object.js
+++ b/app/src/controllers/object.js
@@ -525,7 +525,7 @@ const controller = {
 
         // Present download url link
         if (req.query.download && req.query.download === DownloadMode.URL) {
-          res.status(200).json(signedUrl);
+          res.status(201).json(signedUrl);
         // Download via HTTP redirect
         } else {
           res.status(302).set('Location', signedUrl).end();

--- a/app/src/docs/v1.api-spec.yaml
+++ b/app/src/docs/v1.api-spec.yaml
@@ -189,8 +189,10 @@ paths:
     get:
       summary: Returns the object
       description: >-
-        Returns the object as either a direct binary stream or HTTP 302 redirect
-        to a direct, temporary pre-signed S3 object URL location.
+        Returns the object as either a direct binary stream, an HTTP 201
+        containing a direct, temporary pre-signed S3 object URL location, or
+        an HTTP 302 redirect to a direct, temporary pre-signed S3 object URL
+        location.
       operationId: readObject
       tags:
         - Object
@@ -226,6 +228,12 @@ paths:
               schema:
                 type: string
                 format: binary
+        '201':
+          description: Returns a Presigned S3 URL
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Response-PresignedURL'
         '302':
           $ref: '#/components/responses/S3Found'
         '304':
@@ -795,11 +803,14 @@ components:
     Query-Download:
       in: query
       name: download
-      description: Request to directly download the object as a binary stream
+      description: >-
+        Download mode behavior. Default behavior (undefined) will yield an
+        HTTP 302 redirect to the S3 bucket via presigned URL. If `proxy` is
+        specified, the object contents will be available proxied through COMS.
+        If `url` is specified, expect an HTTP 201 cotaining the presigned URL
+        as a JSON string in the response.
       schema:
-        type: boolean
-        default: false
-        example: true
+        $ref: '#/components/schemas/DownloadMode'
     Query-Email:
       in: query
       name: email
@@ -1160,6 +1171,13 @@ components:
               default: true
               example: true
         - $ref: '#/components/schemas/DB-TimestampUserData'
+    DownloadMode:
+      type: string
+      description: Download mode behavior overrides
+      enum:
+        - proxy
+        - url
+      example: proxy
     PermCode:
       type: string
       description: Permission code/type for an object
@@ -1264,6 +1282,12 @@ components:
           format: int32
           description: a version identifier created in S3
           example: 1647462569641
+    Response-PresignedURL:
+      title: Presigned URL
+      type: string
+      description: A Presigned S3 URL
+      example: >-
+        https://your.objectstore.com/yourbucket/coms/env/00000000-0000-0000-0000-000000000000?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Content-Sha256=UNSIGNED-PAYLOAD&X-Amz-Credential=credential%2F20220411%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20220411T204528Z&X-Amz-Expires=300&X-Amz-Signature=SIGNATURE&X-Amz-SignedHeaders=host&x-id=GetObject
     Response-Problem:
       required:
         - type

--- a/app/src/validators/common.js
+++ b/app/src/validators/common.js
@@ -40,7 +40,7 @@ const scheme = {
 
   string: oneOrMany(Joi.string().max(255)),
 
-  permCode: oneOrMany(Joi.string().max(255).valid(...Object.values(Permissions)))
+  permCode: oneOrMany(Joi.string().valid(...Object.values(Permissions)))
 };
 
 module.exports = { oneOrMany, scheme, type };

--- a/app/src/validators/object.js
+++ b/app/src/validators/object.js
@@ -1,5 +1,7 @@
 const { validate, Joi } = require('express-validation');
+
 const { scheme, type } = require('./common');
+const { DownloadMode } = require('../components/constants');
 
 const schema = {
   deleteObject: {
@@ -30,7 +32,7 @@ const schema = {
     query: Joi.object({
       versionId: Joi.string(),
       expiresIn: Joi.number(),
-      download: type.truthy
+      download: Joi.string().valid(...Object.values(DownloadMode)),
     })
   },
 

--- a/app/src/validators/permission.js
+++ b/app/src/validators/permission.js
@@ -28,7 +28,7 @@ const schema = {
     body: Joi.array().items(
       Joi.object().keys({
         userId: type.uuidv4.required(),
-        permCode: Joi.string().max(255).required().valid(...Object.values(Permissions)),
+        permCode: Joi.string().required().valid(...Object.values(Permissions)),
       })
     ).required(),
   },

--- a/app/tests/unit/validators/common.spec.js
+++ b/app/tests/unit/validators/common.spec.js
@@ -304,14 +304,6 @@ describe('scheme', () => {
             items: expect.arrayContaining([
               expect.objectContaining({
                 type: 'string',
-                rules: expect.arrayContaining([
-                  expect.objectContaining({
-                    args: {
-                      limit: 255
-                    },
-                    name: 'max'
-                  })
-                ]),
                 allow: expect.arrayContaining(Object.values(Permissions))
               })
             ])
@@ -328,14 +320,6 @@ describe('scheme', () => {
             items: expect.arrayContaining([
               expect.objectContaining({
                 type: 'string',
-                rules: expect.arrayContaining([
-                  expect.objectContaining({
-                    args: {
-                      limit: 255
-                    },
-                    name: 'max'
-                  })
-                ]),
                 allow: expect.arrayContaining(Object.values(Permissions))
               })
             ])

--- a/app/tests/unit/validators/object.spec.js
+++ b/app/tests/unit/validators/object.spec.js
@@ -1,6 +1,7 @@
 const crypto = require('crypto');
 const { Joi } = require('express-validation');
 const jestJoi = require('jest-joi');
+const { DownloadMode } = require('../../../src/components/constants');
 expect.extend(jestJoi.matchers);
 
 const schema = require('../../../src/validators/object').schema;
@@ -100,7 +101,10 @@ describe('readObject', () => {
       const download = query.keys.download;
 
       it('is the expected schema', () => {
-        expect(download).toEqual(type.truthy.describe());
+        expect(download).toEqual(expect.objectContaining({
+          type: 'string',
+          allow: expect.arrayContaining(Object.values(DownloadMode))
+        }));
       });
     });
   });

--- a/app/tests/unit/validators/permission.spec.js
+++ b/app/tests/unit/validators/permission.spec.js
@@ -135,14 +135,6 @@ describe('addPermissions', () => {
             permCode: expect.objectContaining({
               type: 'string',
               flags: expect.objectContaining({ presence: 'required' }),
-              rules: expect.arrayContaining([
-                expect.objectContaining({
-                  name: 'max',
-                  args: {
-                    limit: 255
-                  }
-                })
-              ]),
               allow: expect.arrayContaining(Object.values(Permissions))
             })
           })


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

<!-- Describe your changes in detail -->
We need the ability to yield just the signedUrl in addition to the existing proxy and redirect behaviors. This achieves that by allowing `download=url` to yield just the presigned S3 url.
Since we are also defining an explicit list of valid strings for `permCode`, the 255 max length rule is redundant.
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
[SHOWCASE-2773](https://apps.nrs.gov.bc.ca/int/jira/browse/SHOWCASE-2773)

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
New feature (non-breaking change which adds functionality)
<!-- Documentation (non-breaking change with enhancements to documentation) -->
Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->