### PR TITLE
Separate Metadata and Metadada joins in service

### DIFF
--- a/app/src/components/utils.js
+++ b/app/src/components/utils.js
@@ -22,17 +22,6 @@ const utils = {
   },
 
   /**
-   * @function toLowerCaseKeys
-   * @param {object} obj an object with keys of mixed-case
-   * @returns {object} the input object with keys converted to lowercase
-   */
-  toLowerCaseKeys(obj){
-    return Object.fromEntries(Object.entries(obj).map(entry => {
-      return [entry[0].toLowerCase(), entry[1]];
-    }));
-  },
-
-  /**
    * @function delimit
    * Yields a string `s` that will always have a trailing delimiter. Returns an empty string if falsy.
    * @param {string} s The input string
@@ -134,7 +123,7 @@ const utils = {
   getMetadata(obj) {
     return Object.fromEntries(Object.keys(obj)
       .filter((key) => key.toLowerCase().startsWith('x-amz-meta-'))
-      .map((key) => ([key.substring(11), obj[key]]))
+      .map((key) => ([key.toLowerCase().substring(11), obj[key]]))
     );
   },
 
@@ -196,15 +185,15 @@ const utils = {
   },
 
   /**
-   * @function getTagsByKeyValue
-   * get tag objects in array that have given key and value
-   * @param {object[]} tags and array of tags (eg: [{ key: 'a', value: '1'}, { key: 'b', value: '1'}]
-   * @param {string} key the string to match in the tag's `key` property
-   * @param {string} value the string to match in the tag's `value` property
-   * @returns {object[]} an array of matching tag objects
+   * @function getObjectsByKeyValue
+   * get tag/metadata objects in array that have given key and value
+   * @param {object[]} array and array of objects (eg: [{ key: 'a', value: '1'}, { key: 'b', value: '1'}]
+   * @param {string} key the string to match in the objects's `key` property
+   * @param {string} value the string to match in the objects's `value` property
+   * @returns {object[]} an array of matching objects
    */
-  getTagsByKeyValue(tags, key, value){
-    return tags.find(tag => (tag.key === key && tag.value === value));
+  getObjectsByKeyValue(array, key, value){
+    return array.find(obj => (obj.key === key && obj.value === value));
   },
 
   /**

--- a/app/src/db/models/tables/metadata.js
+++ b/app/src/db/models/tables/metadata.js
@@ -7,6 +7,7 @@ class Metadata extends Model {
 
   static get relationMappings() {
     const Version = require('./version');
+    const VersionMetadata = require('./versionMetadata');
 
     return {
       version: {
@@ -20,7 +21,15 @@ class Metadata extends Model {
           },
           to: 'version.id'
         }
-      }
+      },
+      versionMetadata: {
+        relation: Model.HasManyRelation,
+        modelClass: VersionMetadata,
+        join: {
+          from: 'metadata.id',
+          to: 'version_metadata.metadataId'
+        }
+      },
     };
   }
 

--- a/app/src/docs/v1.api-spec.yaml
+++ b/app/src/docs/v1.api-spec.yaml
@@ -778,6 +778,7 @@ components:
       description: >-
         An arbitrary metadata key/value pair. Must contain the x-amz-meta-
         prefix to be valid. Multiple metadata pairs can be defined.
+        keys must be unique and will be converted to lowercase.
       schema:
         type: string
         example:

--- a/app/src/services/metadata.js
+++ b/app/src/services/metadata.js
@@ -1,53 +1,145 @@
 const { NIL: SYSTEM_USER } = require('uuid');
 const { Metadata, VersionMetadata } = require('../db/models');
-const { getKeyValue } = require('../components/utils');
+const { getObjectsByKeyValue } = require('../components/utils');
 
 /**
  * The Metadata DB Service
  */
 const service = {
 
+
   /**
-   * @function updateMetadata
-   * Updates metadata and relates them to the associated version
-   * Un-relates any existing metadata for this version
+   * @function associateMetadata
+   * Makes the incoming list of metadata the definitive set associated with versionId
+   * Dissociaate extraneous metadata and also does collision detection for null versions (non-versioned)
    * @param {string} versionId The uuid id column from version table
-   * @param {object} metadata Incoming object with `<key>:<value>` metadata to add for this version
+   * @param {object[]} metadata Incoming array of metadata objects to add for this version (eg: [{ key: 'a', value: '1'}, {key: 'B', value: '2'}]).
+   * This will always be the difinitive metadata we want on the version
    * @param {string} [currentUserId=SYSTEM_USER] The optional userId uuid actor; defaults to system user if unspecified
    * @param {object} [etrx=undefined] An optional Objection Transaction object
    * @returns {Promise<object>} The result of running the insert operation
    * @throws The error encountered upon db transaction failure
    */
-  updateMetadata: async (versionId, metadata, currentUserId = SYSTEM_USER, etrx = undefined) => {
+  associateMetadata: async (versionId, metadata, currentUserId = SYSTEM_USER, etrx = undefined) => {
     let trx;
     try {
       trx = etrx ? etrx : await Metadata.startTransaction();
       let response = [];
 
-      // convert metadata to array for DB insert query
-      const arr = getKeyValue(metadata);
-      if (arr.length) {
-        // insert/merge metadata records
-        const insertMetadata = await Metadata.query(trx)
-          .insert(arr)
-          .onConflict(['key', 'value'])
-          .merge(); // required to include id's of existing rows in result
+      if (metadata && metadata.length) {
+        // get DB records of all input metadata
+        const dbMetadata = await service.createMetadata(metadata, trx);
 
-        // un-relate all existing version_metadata
-        // this only happens when updating the single 'null version' record in db, when using a non-versioned bucket
-        // otherwise joining records remain in db for previous versions
-        await VersionMetadata.query(trx)
-          .delete()
-          .where('versionId', versionId);
+        // already joined
+        const associatedMetadata = await VersionMetadata.query(trx)
+          .modify('filterVersionId', versionId);
 
-        // add new version_metadata records
-        const relateArray = insertMetadata.map(({id}) => ({
-          versionId: versionId,
-          metadataId: id,
-          createdBy: currentUserId
-        }));
-        response = await VersionMetadata.query(trx)
-          .insert(relateArray);
+        // remove existing joins for metadata that is not in incomming set
+        if (associatedMetadata.length) {
+          const dissociateMetadata = associatedMetadata.filter(({ metadataId }) => !dbMetadata.some(({ id }) => id === metadataId));
+          if (dissociateMetadata.length) {
+            await VersionMetadata.query(trx)
+              .whereIn('id', dissociateMetadata.map(meta => meta.id))
+              .modify('filterVersionId', versionId)
+              .delete();
+
+            // delete all orphaned metadata records
+            await service.pruneOrphanedMetadata(trx);
+          }
+        }
+
+        // join new metadata
+        const newJoins = associatedMetadata.length ? dbMetadata.filter(({ id }) => !associatedMetadata.some(({ metadataId }) => metadataId === id)) : dbMetadata;
+
+        if (newJoins.length) {
+          response = await VersionMetadata.query(trx)
+            .insert(newJoins.map(({ id }) => ({
+              versionId: versionId,
+              metadataId: id,
+              createdBy: currentUserId
+            })));
+        }
+      }
+
+      if (!etrx) await trx.commit();
+      return Promise.resolve(response);
+    } catch (err) {
+      if (!etrx && trx) await trx.rollback();
+      throw err;
+    }
+  },
+
+  /**
+   * @function deleteOrphanedMetadata
+   * deletes Metadata records if they are no longer related to any versions
+   * @param {object} [etrx=undefined] An optional Objection Transaction object
+   * @returns {Promise<number>} The result of running the delete operation (number of rows deleted)
+   * @throws The error encountered upon db transaction failure
+   */
+  // TODO: check if deleteing a version will prune orphan metadata records (sister table)
+  pruneOrphanedMetadata: async (etrx = undefined) => {
+    let trx;
+    try {
+      trx = etrx ? etrx : await Metadata.startTransaction();
+
+      const deletedMetadataIds = await Metadata.query(trx)
+        .allowGraph('versionMetadata')
+        .withGraphJoined('versionMetadata')
+        .select('metadata.id')
+        .whereNull('versionMetadata.metadataId');
+
+      const response = await Metadata.query(trx)
+        .delete()
+        .whereIn('id', deletedMetadataIds.map(({ id }) => id));
+
+      if (!etrx) await trx.commit();
+      return Promise.resolve(response);
+    } catch (err) {
+      if (!etrx && trx) await trx.rollback();
+      throw err;
+    }
+  },
+
+  /**
+   * @function createMetadata
+   * Inserts any metadata records if they dont already exist in db
+   * @param {object} metadata Incoming object with `<key>:<value>` metadata to add for this version
+   * @param {object} [etrx=undefined] An optional Objection Transaction object
+   * @returns {Promise<object>} an array of all input metadata
+   * @throws The error encountered upon db transaction failure
+   */
+  createMetadata: async (metadata, etrx = undefined) => {
+    let trx;
+    let response = [];
+    try {
+      trx = etrx ? etrx : await Metadata.startTransaction();
+
+      // get all metadata already in db
+      const allMetadata = await Metadata.query(trx).select();
+      const existingMetadata = [];
+      const newMetadata = [];
+
+      metadata.forEach(({ key, value }) => {
+        // if metadata is already in db
+        if (getObjectsByKeyValue(allMetadata, key, value)) {
+          // add metadata object to existingMetadata array
+          existingMetadata.push({ id: getObjectsByKeyValue(allMetadata, key, value).id, key: key, value: value });
+        }
+        // else add to array for inserting
+        else {
+          newMetadata.push({ key: key, value: value });
+        }
+      });
+      // insert new metadata
+      if (newMetadata.length) {
+        const newMetadataRecords = await Metadata.query(trx)
+          .insert(newMetadata)
+          .returning('*');
+        // merge new with existing metadata
+        response = existingMetadata.concat(newMetadataRecords);
+      }
+      else {
+        response = existingMetadata;
       }
 
       if (!etrx) await trx.commit();

--- a/app/src/services/tag.js
+++ b/app/src/services/tag.js
@@ -1,6 +1,6 @@
 const { NIL: SYSTEM_USER } = require('uuid');
 const { Tag, VersionTag } = require('../db/models');
-const { getTagsByKeyValue } = require('../components/utils');
+const { getObjectsByKeyValue } = require('../components/utils');
 
 /**
  * The Tag DB Service
@@ -31,7 +31,7 @@ const service = {
 
         // dissociate tags that are no longer associated
         const dissociateTags = current
-          .filter(({ key, value}) => !getTagsByKeyValue(tags, key, value));
+          .filter(({ key, value}) => !getObjectsByKeyValue(tags, key, value));
         if (dissociateTags.length) await service.dissociateTags(versionId, dissociateTags, trx);
 
         // associate tags
@@ -70,6 +70,9 @@ const service = {
         // get all currently associated tags
         const associatedTags = await VersionTag.query(trx)
           .modify('filterVersionId', versionId);
+
+        // TODO: exclude tags (with matching key vand value) that are already joined
+        // lets us use associateTags in addTags controller
 
         // associate remaining tags
         const newJoins = dbTags.filter(({ id }) => {
@@ -189,8 +192,8 @@ const service = {
 
       tags.forEach(({ key, value }) => {
         // if tag is already in db
-        if (getTagsByKeyValue(allTags, key, value)){
-          existingTags.push({ id: getTagsByKeyValue(allTags, key, value).id, key: key, value: value });
+        if (getObjectsByKeyValue(allTags, key, value)){
+          existingTags.push({ id: getObjectsByKeyValue(allTags, key, value).id, key: key, value: value });
         }
         // else add to array for inserting
         else {

--- a/app/src/services/version.js
+++ b/app/src/services/version.js
@@ -111,6 +111,9 @@ const service = {
         // https://vincit.github.io/objection.js/recipes/returning-tricks.html
         .returning('*')
         .throwIfNotFound();
+
+      // TODO: prune metadata and tags
+
       if (!etrx) await trx.commit();
       return Promise.resolve(response);
     } catch (err) {

--- a/app/tests/unit/components/utils.spec.js
+++ b/app/tests/unit/components/utils.spec.js
@@ -41,8 +41,8 @@ describe('getMetadata', () => {
     expect(utils.getMetadata(headers)).toEqual({
       foo: 'bar',
       baz: 'quz',
-      Bam: 'blam',
-      rUn: 'ran'
+      bam: 'blam',
+      run: 'ran'
     });
   });
 });

--- a/app/tests/unit/controllers/object.spec.js
+++ b/app/tests/unit/controllers/object.spec.js
@@ -30,7 +30,7 @@ describe('addMetadata', () => {
   const storageHeadObjectSpy = jest.spyOn(storageService, 'headObject');
   const storageCopyObjectSpy = jest.spyOn(storageService, 'copyObject');
   const versionCopySpy = jest.spyOn(versionService, 'copy');
-  const metadataUpdateMetadataSpy = jest.spyOn(metadataService, 'updateMetadata');
+  const metadataAssociateMetadataSpy = jest.spyOn(metadataService, 'associateMetadata');
   const trxWrapperSpy = jest.spyOn(utils, 'trxWrapper');
   const setHeadersSpy = jest.spyOn(controller, '_processS3Headers');
 
@@ -82,7 +82,7 @@ describe('addMetadata', () => {
     storageCopyObjectSpy.mockResolvedValue(GoodResponse);
     trxWrapperSpy.mockImplementation(callback => callback({}));
     versionCopySpy.mockReturnValue({id: '5dad1ec9-d3c0-4b0f-8ead-cb4d9fa98987'});
-    metadataUpdateMetadataSpy.mockReturnValue({});
+    metadataAssociateMetadataSpy.mockReturnValue({});
     setHeadersSpy.mockImplementation(x => x);
 
     await controller.addMetadata(req, res, next);
@@ -101,7 +101,7 @@ describe('addMetadata', () => {
 
     expect(trxWrapperSpy).toHaveBeenCalledTimes(1);
     expect(versionCopySpy).toHaveBeenCalledTimes(1);
-    expect(metadataUpdateMetadataSpy).toHaveBeenCalledTimes(1);
+    expect(metadataAssociateMetadataSpy).toHaveBeenCalledTimes(1);
     expect(res.status).toHaveBeenCalledWith(204);
   });
 });


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

ticket: https://apps.nrs.gov.bc.ca/int/jira/browse/SHOWCASE-2783

Similar to the PR 67. Try to separate metadata service calls.
with metadata edits a new version is created UNLESS versioning is disabled.
so the collision detection is a bit different.

I've put the process of creating the Metadata records into its own separate function that does collision detection..

The other function associateMetadata() can be used for both add, replace and delete.
I could have put in a separate function that does just add but it seems unnecessary.

We should do a lot of testing against this PR deployment.

PruneOrphanMetdata() will need to be called when we call the deleteObject() controller.. which can be done in a separate PR.



## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [ ] I have checked that unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->