### PR TITLE
add bucket ids to create and read

### DIFF
--- a/app/src/controllers/object.js
+++ b/app/src/controllers/object.js
@@ -202,6 +202,14 @@ const controller = {
       const objects = [];
       const userId = await userService.getCurrentUserId(getCurrentIdentity(req.currentUser, SYSTEM_USER));
 
+      let bucketId = undefined;
+      bb.on('field', (fieldname, val) => {
+        // We only handle 'bucketId' at this point
+        if(fieldname === 'bucketId') {
+          bucketId = val;
+        }
+      });
+
       bb.on('file', (name, stream, info) => {
         const objId = uuidv4();
 
@@ -215,6 +223,7 @@ const controller = {
             id: objId
           },
           tags: req.query.tagset,
+          bucketId: bucketId
         };
 
         // TODO: Consider refactoring to use Upload instead from @aws-sdk/lib-storage
@@ -690,6 +699,7 @@ const controller = {
       const tagging = req.query.tagset;
       const params = {
         id: objIds ? objIds.map(id => addDashesToUuid(id)) : objIds,
+        bucketId: req.query.bucketId,
         name: req.query.name,
         path: req.query.path,
         mimeType: req.query.mimeType,

--- a/app/src/services/object.js
+++ b/app/src/services/object.js
@@ -99,7 +99,7 @@ const service = {
     return ObjectModel.query()
       .allowGraph('[objectPermission, version]')
       .modify('filterIds', params.id)
-      .modify('filterBucketIds', params.id)
+      .modify('filterBucketIds', params.bucketId)
       .modify('filterPath', params.path)
       .modify('filterPublic', params.public)
       .modify('filterActive', params.active)

--- a/app/src/validators/object.js
+++ b/app/src/validators/object.js
@@ -117,6 +117,7 @@ const schema = {
     headers: type.metadata(0),
     query: Joi.object({
       objId: scheme.guid,
+      bucketId: scheme.guid,
       name: Joi.string(),
       path: Joi.string().max(1024),
       mimeType: Joi.string().max(255),


### PR DESCRIPTION
Signed-off-by: Lucas ONeil <lucasoneil@gmail.com>

<!-- Provide a general summary of your changes in the Title above -->
# Description
Handle the bucket ID in object create and search operations.

For create, get the bucket ID out of the multi part form data to pass to the service.
For search, there was a typo in the param name, and added validation and param parsing.

Tested leaving the bucket ID out in the call for each of these as well to make sure it handles when it's not provided.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue) 
New feature (non-breaking change which adds functionality) 
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->