### PR TITLE
add 'bucketId' as input param for  GET permission/object

### DIFF
--- a/app/src/components/utils.js
+++ b/app/src/components/utils.js
@@ -140,6 +140,34 @@ const utils = {
   },
 
   /**
+   * @function groupByObject
+   * Re-structure array of nested objects
+   * ref: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/reduce#grouping_objects_by_a_property
+   * @param {object[]} objectArray  array of objects
+   * @param {string} property key (or property accessor) to group by
+   * @param {string} group attribute name for nested group
+   * @returns {object[]} returns an array of Objects, each with nested group of objects
+   */
+  groupByObject(objectArray, property, group) {
+    return objectArray.reduce((acc, obj) => {
+      // value of the 'property' attribute of obj
+      const val = obj[property];
+      // does accumulator array contain an object with permissions matching obj
+      const el = acc.find((ob) => {
+        return ob[group].some((p) =>  p[property] === val );
+      });
+      if (el) {
+        // add object to current object's permissions array
+        el[group].push(obj);
+      } else {
+        // add to a new top level element in accumulator array
+        acc.push({ [property]: val, [group]: [obj] });
+      }
+      return acc;
+    }, []);
+  },
+
+  /**
    * @function isTruthy
    * Returns true if the element name in the object contains a truthy value
    * @param {object} value The object to evaluate

--- a/app/src/db/models/tables/objectPermission.js
+++ b/app/src/db/models/tables/objectPermission.js
@@ -44,6 +44,14 @@ class ObjectPermission extends Timestamps(Model) {
 
   static get modifiers() {
     return {
+      filterBucketId(query, value) {
+        if (value) {
+          query
+            .select('object_permission.*')
+            .joinRelated('object')
+            .whereIn('object.bucketId', value);
+        }
+      },
       filterUserId(query, value) {
         filterOneOrMany(query, value, 'userId');
       },

--- a/app/src/services/objectPermission.js
+++ b/app/src/services/objectPermission.js
@@ -111,6 +111,7 @@ const service = {
   /**
    * @function searchPermissions
    * Search and filter for specific object permissions
+   * @param {string|string[]} [params.bucketId] Optional string or array of uuids representing the bucket
    * @param {string|string[]} [params.userId] Optional string or array of uuids representing the user
    * @param {string|string[]} [params.objId] Optional string or array of uuids representing the object
    * @param {string|string[]} [params.permCode] Optional string or array of permission codes
@@ -118,6 +119,7 @@ const service = {
    */
   searchPermissions: (params) => {
     return ObjectPermission.query()
+      .modify('filterBucketId', params.bucketId)
       .modify('filterUserId', params.userId)
       .modify('filterObjectId', params.objId)
       .modify('filterPermissionCode', params.permCode);

--- a/app/src/validators/objectPermission.js
+++ b/app/src/validators/objectPermission.js
@@ -5,6 +5,7 @@ const { Permissions } = require('../components/constants');
 const schema = {
   searchPermissions: {
     query: Joi.object({
+      bucketId: scheme.guid,
       userId: scheme.guid,
       objId: scheme.guid,
       permCode: scheme.permCode

--- a/app/tests/unit/controllers/objectPermission.spec.js
+++ b/app/tests/unit/controllers/objectPermission.spec.js
@@ -2,6 +2,7 @@ const Problem = require('api-problem');
 
 const controller = require('../../../src/controllers/objectPermission');
 const { objectPermissionService, userService } = require('../../../src/services');
+const utils = require('../../../src/components/utils');
 
 const mockResponse = () => {
   const res = {};
@@ -19,21 +20,23 @@ describe('searchPermissions', () => {
   });
 
   const searchPermissionsSpy = jest.spyOn(objectPermissionService, 'searchPermissions');
+  const groupByObjectSpy = jest.spyOn(utils, 'groupByObject');
 
   const req = {
-    query: { objId: 'xyz-789', userId: 'oid-1d', permCode: 'pc' }
+    query: { bucketId: 'abc', objId: 'xyz-789', userId: 'oid-1d', permCode: 'pc' }
   };
   const next = jest.fn();
 
   it('should return the permission service searchPermissions result', async () => {
     searchPermissionsSpy.mockReturnValue({ res: 123 });
+    groupByObjectSpy.mockReturnValue([]);
 
     const res = mockResponse();
     await controller.searchPermissions(req, res, next);
     expect(searchPermissionsSpy).toHaveBeenCalledTimes(1);
-    expect(searchPermissionsSpy).toHaveBeenCalledWith({ objId: [req.query.objId], userId: [req.query.userId], permCode: [req.query.permCode] });
+    expect(searchPermissionsSpy).toHaveBeenCalledWith({ bucketId: [req.query.bucketId], objId: [req.query.objId], userId: [req.query.userId], permCode: [req.query.permCode] });
     expect(res.status).toHaveBeenCalledWith(200);
-    expect(res.json).toHaveBeenCalledWith({ res: 123 });
+    expect(res.json).toHaveBeenCalledWith([]);
     expect(next).toHaveBeenCalledTimes(0);
   });
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description
ticket: https://apps.nrs.gov.bc.ca/int/jira/browse/SHOWCASE-2948

extend GET /permission/object endpoint
Add optional bucketId query parameter to assist with scoping the number of outputs in the response.
Utils function for restructuring array of objects.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [ ] I have checked that unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->