### PR TITLE
Expose GET /object and /bucket endpoints

### DIFF
--- a/app/src/components/utils.js
+++ b/app/src/components/utils.js
@@ -152,12 +152,12 @@ const utils = {
     return objectArray.reduce((acc, obj) => {
       // value of the 'property' attribute of obj
       const val = obj[property];
-      // does accumulator array contain an object with permissions matching obj
+      // does accumulator array have element with nested array containing current obj
       const el = acc.find((ob) => {
         return ob[group].some((p) => p[property] === val);
       });
       if (el) {
-        // add object to current object's permissions array
+        // add to current element's nested array
         el[group].push(obj);
       } else {
         // add to a new top level element in accumulator array

--- a/app/src/controllers/object.js
+++ b/app/src/controllers/object.js
@@ -3,7 +3,6 @@ const cors = require('cors');
 const { v4: uuidv4, NIL: SYSTEM_USER } = require('uuid');
 
 const {
-  AuthMode,
   DownloadMode,
   MAXCOPYOBJECTLENGTH,
   MetadataDirective
@@ -11,7 +10,6 @@ const {
 const errorToProblem = require('../components/errorToProblem');
 const {
   addDashesToUuid,
-  getAppAuthMode,
   getKeyValue,
   toLowerKeys,
   getMetadata,
@@ -32,8 +30,6 @@ const {
 } = require('../services');
 
 const SERVICE = 'ObjectService';
-
-const authMode = getAppAuthMode();
 
 /**
  * The Object Controller
@@ -691,6 +687,7 @@ const controller = {
       const params = {
         id: objIds ? objIds.map(id => addDashesToUuid(id)) : objIds,
         bucketId: req.query.bucketId,
+        userId: req.query.userId,
         name: req.query.name,
         path: req.query.path,
         mimeType: req.query.mimeType,
@@ -700,10 +697,6 @@ const controller = {
         active: isTruthy(req.query.active)
       };
 
-      // When using OIDC authentication, force populate current user as filter if available
-      if (authMode === AuthMode.OIDCAUTH || authMode === AuthMode.FULLAUTH) {
-        params.userId = await userService.getCurrentUserId(getCurrentIdentity(req.currentUser, SYSTEM_USER));
-      }
       const response = await objectService.searchObjects(params);
       res.status(201).json(response);
     } catch (error) {

--- a/app/src/controllers/objectPermission.js
+++ b/app/src/controllers/objectPermission.js
@@ -23,11 +23,11 @@ const controller = {
     try {
       const bucketIds = utils.mixedQueryToArray(req.query.bucketId);
       const objIds = utils.mixedQueryToArray(req.query.objId);
-      const userIds = utils.mixedQueryToArray(req.query.userId);
+      const userId = req.query.userId;
       const result = await objectPermissionService.searchPermissions({
         bucketId: bucketIds ? bucketIds.map(id => utils.addDashesToUuid(id)) : bucketIds,
         objId: objIds ? objIds.map(id => utils.addDashesToUuid(id)) : objIds,
-        userId: userIds ? userIds.map(id => utils.addDashesToUuid(id)) : userIds,
+        userId: userId ? utils.addDashesToUuid(userId) : userId,
         permCode: utils.mixedQueryToArray(req.query.permCode)
       });
       const response = utils.groupByObject('objectId', 'permissions', result);

--- a/app/src/docs/v1.api-spec.yaml
+++ b/app/src/docs/v1.api-spec.yaml
@@ -147,11 +147,7 @@ paths:
       summary: Search for objects
       description: >-
         Returns a list of objects matching all search criteria across all known
-        versions of objects. If the request is BasicAuth authenticated, all
-        search and filtered results will appear. However, If the request is
-        BearerAuth authenticated, only objects that the user has at least one
-        permission associated with, will appear in addition to their filtering
-        parameters.
+        versions of objects.
       operationId: searchObjects
       tags:
         - Object
@@ -163,6 +159,7 @@ paths:
         - $ref: '#/components/parameters/Query-Public'
         - $ref: '#/components/parameters/Query-MimeType'
         - $ref: '#/components/parameters/Query-Name'
+        - $ref: '#/components/parameters/Query-UserId'
         - $ref: '#/components/parameters/Query-TagSet'
       responses:
         '201':

--- a/app/src/validators/bucket.js
+++ b/app/src/validators/bucket.js
@@ -36,6 +36,7 @@ const schema = {
 
   searchBuckets: {
     query: Joi.object({
+      userId: type.uuidv4,
       bucketId: scheme.guid,
       bucketName: Joi.string().max(255),
       key: Joi.string().max(255),

--- a/app/src/validators/object.js
+++ b/app/src/validators/object.js
@@ -120,6 +120,7 @@ const schema = {
   searchObjects: {
     headers: type.metadata(0),
     query: Joi.object({
+      userId: type.uuidv4,
       objId: scheme.guid,
       bucketId: scheme.guid,
       name: Joi.string(),

--- a/app/tests/unit/controllers/objectPermission.spec.js
+++ b/app/tests/unit/controllers/objectPermission.spec.js
@@ -34,7 +34,7 @@ describe('searchPermissions', () => {
     const res = mockResponse();
     await controller.searchPermissions(req, res, next);
     expect(searchPermissionsSpy).toHaveBeenCalledTimes(1);
-    expect(searchPermissionsSpy).toHaveBeenCalledWith({ bucketId: [req.query.bucketId], objId: [req.query.objId], userId: [req.query.userId], permCode: [req.query.permCode] });
+    expect(searchPermissionsSpy).toHaveBeenCalledWith({ bucketId: [req.query.bucketId], objId: [req.query.objId], userId: req.query.userId, permCode: [req.query.permCode] });
     expect(res.status).toHaveBeenCalledWith(200);
     expect(res.json).toHaveBeenCalledWith([]);
     expect(next).toHaveBeenCalledTimes(0);


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->
# Description

Add userId as an optional query parameters for both `GET /object` and `GET /bucket` endpoints.. so users can acquire "data" about the object even if they do not have explicit permissions for it.

ticket: https://apps.nrs.gov.bc.ca/int/jira/browse/SHOWCASE-2948
see 2nd and 3rd changes in: https://gist.github.com/jujaga/ca344f79c81e05796af04b44b30038ca#problem-2-proposal


<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->