### PR TITLE
Feat/2927 bucket object permissions

### DIFF
--- a/app/src/components/utils.js
+++ b/app/src/components/utils.js
@@ -154,7 +154,7 @@ const utils = {
       const val = obj[property];
       // does accumulator array contain an object with permissions matching obj
       const el = acc.find((ob) => {
-        return ob[group].some((p) =>  p[property] === val );
+        return ob[group].some((p) => p[property] === val);
       });
       if (el) {
         // add object to current object's permissions array
@@ -221,7 +221,7 @@ const utils = {
    * @param {string} value the string to match in the objects's `value` property
    * @returns {object[]} an array of matching objects
    */
-  getObjectsByKeyValue(array, key, value){
+  getObjectsByKeyValue(array, key, value) {
     return array.find(obj => (obj.key === key && obj.value === value));
   },
 

--- a/app/src/components/utils.js
+++ b/app/src/components/utils.js
@@ -143,12 +143,12 @@ const utils = {
    * @function groupByObject
    * Re-structure array of nested objects
    * ref: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/reduce#grouping_objects_by_a_property
-   * @param {object[]} objectArray  array of objects
    * @param {string} property key (or property accessor) to group by
    * @param {string} group attribute name for nested group
+   * @param {object[]} objectArray array of objects
    * @returns {object[]} returns an array of Objects, each with nested group of objects
    */
-  groupByObject(objectArray, property, group) {
+  groupByObject(property, group, objectArray) {
     return objectArray.reduce((acc, obj) => {
       // value of the 'property' attribute of obj
       const val = obj[property];

--- a/app/src/controllers/bucketPermission.js
+++ b/app/src/controllers/bucketPermission.js
@@ -39,6 +39,7 @@ const controller = {
       if (isTruthy(req.query.objectPerms)) { 
         // Iteration through bucket and object permissions. If object permission not found, set empty array.   
         const bucketIds = await bucketPermissionService.getBucketIdsWithObject(userIds);
+        
         bucketIds.forEach(bucketId => {
           if (!response.map(r => r.bucketId).includes(bucketId)) {
             response.push({

--- a/app/src/controllers/objectPermission.js
+++ b/app/src/controllers/objectPermission.js
@@ -30,7 +30,7 @@ const controller = {
         userId: userIds ? userIds.map(id => utils.addDashesToUuid(id)) : userIds,
         permCode: utils.mixedQueryToArray(req.query.permCode)
       });
-      const response = utils.groupByObject(result, 'objectId', 'permissions');
+      const response = utils.groupByObject('objectId', 'permissions', result);
       res.status(200).json(response);
     } catch (e) {
       next(errorToProblem(SERVICE, e));

--- a/app/src/controllers/objectPermission.js
+++ b/app/src/controllers/objectPermission.js
@@ -30,9 +30,7 @@ const controller = {
         userId: userIds ? userIds.map(id => utils.addDashesToUuid(id)) : userIds,
         permCode: utils.mixedQueryToArray(req.query.permCode)
       });
-
       const response = utils.groupByObject(result, 'objectId', 'permissions');
-
       res.status(200).json(response);
     } catch (e) {
       next(errorToProblem(SERVICE, e));

--- a/app/src/services/bucketPermission.js
+++ b/app/src/services/bucketPermission.js
@@ -117,9 +117,9 @@ const service = {
   getBucketIdsWithObject: async (userId) => {
     return ObjectPermission.query()
       .select('bucketId')
-      .modify('filterUserId', userId)
+      .distinct('userId')
       .joinRelated('object')
-      .whereIn('userId', userId)
+      .modify('filterUserId', userId)
       .whereNotNull('bucketId')
       .then(response => response.map(entry => entry.bucketId));
   },

--- a/app/src/services/bucketPermission.js
+++ b/app/src/services/bucketPermission.js
@@ -114,12 +114,12 @@ const service = {
    * @param {string|string[]} [params.userId] Optional string or array of uuids representing the user
    * @returns {Promise<object>} The result of running the find operation
    */
-  getBucketIdsWithObject: async (userIds) => {
+  getBucketIdsWithObject: async (userId) => {
     return ObjectPermission.query()
       .select('bucketId')
-      .distinct('bucketId')
+      .modify('filterUserId', userId)
       .joinRelated('object')
-      .whereIn('userId', userIds)
+      .whereIn('userId', userId)
       .whereNotNull('bucketId')
       .then(response => response.map(entry => entry.bucketId));
   },

--- a/app/src/services/bucketPermission.js
+++ b/app/src/services/bucketPermission.js
@@ -1,7 +1,7 @@
 const { v4: uuidv4, NIL: SYSTEM_USER } = require('uuid');
 
 const { Permissions } = require('../components/constants');
-const { BucketPermission } = require('../db/models');
+const { BucketPermission, ObjectPermission } = require('../db/models');
 
 /**
  * The Bucket Permission DB Service
@@ -106,6 +106,22 @@ const service = {
       if (!etrx && trx) await trx.rollback();
       throw err;
     }
+  },
+
+  /**
+   * @function getBucketIdsWithObject
+   * Searches for specific (bucket) object permissions
+   * @param {string|string[]} [params.userId] Optional string or array of uuids representing the user
+   * @returns {Promise<object>} The result of running the find operation
+   */
+  getBucketIdsWithObject: async (userIds) => {
+    return ObjectPermission.query()
+      .select('bucketId')
+      .distinct('bucketId')
+      .joinRelated('object')
+      .whereIn('userId', userIds)
+      .whereNotNull('bucketId')
+      .then(response => response.map(entry => entry.bucketId));
   },
 
   /**

--- a/app/src/validators/bucketPermission.js
+++ b/app/src/validators/bucketPermission.js
@@ -5,10 +5,10 @@ const { Permissions } = require('../components/constants');
 const schema = {
   searchPermissions: {
     query: Joi.object({
+      objectPerms: type.truthy,
       userId: scheme.guid,
       bucketId: scheme.guid,
-      permCode: scheme.permCode,
-      objectPerms: type.truthy
+      permCode: scheme.permCode
     }).min(1)
   },
 

--- a/app/src/validators/bucketPermission.js
+++ b/app/src/validators/bucketPermission.js
@@ -7,7 +7,8 @@ const schema = {
     query: Joi.object({
       userId: scheme.guid,
       bucketId: scheme.guid,
-      permCode: scheme.permCode
+      permCode: scheme.permCode,
+      objectPerms: type.truthy
     }).min(1)
   },
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

Altering 'bucketPermissions.searchPermissions' endpoint to accept a boolean query parameter called 'objectPerms=true'. When this is provided, implicit buckets will also be listed, even though they have no permissions bound to them. API response is now an array of arrays instead of just an array.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [ ] I have checked that unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->