### PR TITLE
Use database default for delete-marker version

### DIFF
--- a/app/src/controllers/object.js
+++ b/app/src/controllers/object.js
@@ -370,8 +370,7 @@ const controller = {
           const deleteMarker = {
             id: objId,
             deleteMarker: true,
-            versionId: s3Response.VersionId,
-            mimeType: null
+            versionId: s3Response.VersionId
           };
           await versionService.create(deleteMarker, userId);
         } else { // else object in bucket is not versioned

--- a/app/src/db/models/tables/version.js
+++ b/app/src/db/models/tables/version.js
@@ -66,7 +66,7 @@ class Version extends Timestamps(Model) {
   static get jsonSchema() {
     return {
       type: 'object',
-      required: ['objectId', 'mimeType'],
+      required: ['objectId'],
       properties: {
         id: { type: 'string', minLength: 1, maxLength: 255 },
         versionId: { type: ['string', 'null'], maxLength: 1024 },

--- a/app/tests/unit/controllers/object.spec.js
+++ b/app/tests/unit/controllers/object.spec.js
@@ -319,7 +319,6 @@ describe('deleteObject', () => {
       id: 'xyz-789',
       deleteMarker: true,
       versionId: '1234',
-      mimeType: null,
     }, 'user-123');
   });
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

when adding a delete marker we should not specify a mimeType (previously we were using null).
now we default to db column default of 'application/octet-stream'

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [ ] I have checked that unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->