### PR TITLE
Do not convert identityId to uuid

### DIFF
--- a/app/src/controllers/user.js
+++ b/app/src/controllers/user.js
@@ -38,10 +38,9 @@ const controller = {
   async searchUsers(req, res, next) {
     try {
       const userIds = mixedQueryToArray(req.query.userId);
-      const identityIds = mixedQueryToArray(req.query.identityId);
       const response = await userService.searchUsers({
         userId: userIds ? userIds.map(id => addDashesToUuid(id)) : userIds,
-        identityId: identityIds ? identityIds.map(id => addDashesToUuid(id)) : identityIds,
+        identityId: req.query.identityId,
         idp: mixedQueryToArray(req.query.idp),
         username: req.query.username,
         email: req.query.email,

--- a/app/src/controllers/user.js
+++ b/app/src/controllers/user.js
@@ -40,7 +40,7 @@ const controller = {
       const userIds = mixedQueryToArray(req.query.userId);
       const response = await userService.searchUsers({
         userId: userIds ? userIds.map(id => addDashesToUuid(id)) : userIds,
-        identityId: req.query.identityId,
+        identityId: mixedQueryToArray(req.query.identityId),
         idp: mixedQueryToArray(req.query.idp),
         username: req.query.username,
         email: req.query.email,

--- a/app/src/docs/v1.api-spec.yaml
+++ b/app/src/docs/v1.api-spec.yaml
@@ -884,18 +884,15 @@ components:
       in: query
       name: identityId
       description: >-
-        Uuid or array of uuids representing the user (identified by optional
-        `KC_IDENTITYKEY` env variable)
+        String or array of strings representing the user (identified by optional KC_IDENTITYKEY env variable)
       schema:
         oneOf:
           - type: string
-            format: uuid
-            example: 00000000-0000-0000-0000-000000000000
+            example: 5dad1ec9d3c04b0f8eadcb4d9fa98987
           - type: array
             items:
               type: string
-              format: uuid
-              example: 00000000-0000-0000-0000-000000000000
+              example: 5dad1ec9d3c04b0f8eadcb4d9fa98987
     Query-FirstName:
       in: query
       name: firstName
@@ -1197,7 +1194,7 @@ components:
                 Identity id of the user (Usually the sub claim in a JWT but can
                 be redefined to a different claim with the `KC_IDENTITYKEY` env
                 variable)
-              example: 5dad1ec9-d3c0-4b0f-8ead-cb4d9fa98987
+              example: 5dad1ec9d3c04b0f8eadcb4d9fa98987
             idp:
               type: string
               description: Identity provider used by the OIDC server

--- a/app/src/validators/user.js
+++ b/app/src/validators/user.js
@@ -6,7 +6,7 @@ const schema = {
   searchUsers: {
     query: Joi.object({
       userId: scheme.guid,
-      identityId: scheme.guid,
+      identityId: scheme.string,
       idp: scheme.string,
       username: type.alphanum,
       email: type.email,

--- a/app/tests/unit/validators/user.spec.js
+++ b/app/tests/unit/validators/user.spec.js
@@ -135,7 +135,7 @@ describe('searchUsers', () => {
 
     describe('identityId', () => {
       it('is the expected schema', () => {
-        expect(query.keys.identityId).toEqual(scheme.guid.describe());
+        expect(query.keys.identityId).toEqual(scheme.string.describe());
       });
     });
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

IdentityId is stored as a varchar in the db. Attempting to convert it to a uuid in the user search will cause the comparison to fail.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

 Bug fix (non-breaking change which fixes an issue) 
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->