### PR TITLE
Extending get object permissions api

### DIFF
--- a/app/src/controllers/objectPermission.js
+++ b/app/src/controllers/objectPermission.js
@@ -31,6 +31,20 @@ const controller = {
         permCode: utils.mixedQueryToArray(req.query.permCode)
       });
       const response = utils.groupByObject('objectId', 'permissions', result);
+
+      if (utils.isTruthy(req.query.bucketPerms)) {
+        const objectIds = await objectPermissionService.getObjectIdsWithBucket(userId);
+
+        objectIds.forEach(objectId => {
+          if (!response.map(r => r.objectId).includes(objectId)) {
+            response.push({
+              objectId: objectId,
+              permissions: []
+            });
+          }
+        });
+      }
+
       res.status(200).json(response);
     } catch (e) {
       next(errorToProblem(SERVICE, e));

--- a/app/src/controllers/objectPermission.js
+++ b/app/src/controllers/objectPermission.js
@@ -33,7 +33,7 @@ const controller = {
       const response = utils.groupByObject('objectId', 'permissions', result);
 
       if (utils.isTruthy(req.query.bucketPerms)) {
-        const objectIds = await objectPermissionService.getObjectIdsWithBucket(userId);
+        const objectIds = await objectPermissionService.getObjectIdsWithBucket(userId, bucketIds);
 
         objectIds.forEach(objectId => {
           if (!response.map(r => r.objectId).includes(objectId)) {

--- a/app/src/services/objectPermission.js
+++ b/app/src/services/objectPermission.js
@@ -1,7 +1,7 @@
 const { v4: uuidv4, NIL: SYSTEM_USER } = require('uuid');
 
 const { Permissions } = require('../components/constants');
-const { ObjectPermission } = require('../db/models');
+const { ObjectPermission, BucketPermission } = require('../db/models');
 
 /**
  * The Object Permission DB Service
@@ -69,13 +69,11 @@ const service = {
    * @returns {Promise<object>} The result of running the find operation
   */
   getObjectIdsWithBucket: async (userId, bucketId) => {
-    return ObjectPermission.query()
-      .select('objectId')
-      .distinct('userId')
-      .joinRelated('object')
+    return BucketPermission.query()
+      .distinct('object.id AS objectId')
+      .rightJoin('object', 'bucket_permission.bucketId', '=', 'object.bucketId')
       .modify('filterUserId', userId)
-      .modify('filterBucketId', bucketId)
-      .whereNotNull('objectId')
+      .whereIn('bucket_permission.bucketId', bucketId)
       .then(response => response.map(entry => entry.objectId));
   },
 

--- a/app/src/services/objectPermission.js
+++ b/app/src/services/objectPermission.js
@@ -65,7 +65,7 @@ const service = {
    * @function getObjectIdsWithBucket
    * Searches for specific (object) bucket permissions
    * @param {string|string[]} [params.userId] Optional string or array of uuids representing the user
-   * @param {string|string[]} [params.bucketId]
+   * @param {string|string[]} [params.bucketId] Optional string or array of uuids representing the bucket id(s)
    * @returns {Promise<object>} The result of running the find operation
   */
   getObjectIdsWithBucket: async (userId, bucketId) => {

--- a/app/src/services/objectPermission.js
+++ b/app/src/services/objectPermission.js
@@ -1,7 +1,7 @@
 const { v4: uuidv4, NIL: SYSTEM_USER } = require('uuid');
 
 const { Permissions } = require('../components/constants');
-const { ObjectPermission, BucketPermission } = require('../db/models');
+const { BucketPermission, ObjectPermission } = require('../db/models');
 
 /**
  * The Object Permission DB Service

--- a/app/src/services/objectPermission.js
+++ b/app/src/services/objectPermission.js
@@ -71,8 +71,8 @@ const service = {
   getObjectIdsWithBucket: async (userId, bucketId) => {
     return BucketPermission.query()
       .distinct('object.id AS objectId')
-      .rightJoin('object', 'bucket_permission.bucketId', '=', 'object.bucketId')
       .modify('filterUserId', userId)
+      .rightJoin('object', 'bucket_permission.bucketId', '=', 'object.bucketId')
       .whereIn('bucket_permission.bucketId', bucketId)
       .then(response => response.map(entry => entry.objectId));
   },

--- a/app/src/services/objectPermission.js
+++ b/app/src/services/objectPermission.js
@@ -65,7 +65,7 @@ const service = {
    * @function getObjectIdsWithBucket
    * Searches for specific (object) bucket permissions
    * @param {string|string[]} [params.userId] Optional string or array of uuids representing the user
-   * @param {string|string[]} [params.bucketId] Optional string or array of uuids representing the bucket id(s)
+   * @param {string|string[]} [params.bucketId] Optional string or array of bucket id(s)
    * @returns {Promise<object>} The result of running the find operation
   */
   getObjectIdsWithBucket: async (userId, bucketId) => {

--- a/app/src/services/objectPermission.js
+++ b/app/src/services/objectPermission.js
@@ -62,6 +62,24 @@ const service = {
   },
 
   /**
+   * @function getObjectIdsWithBucket
+   * Searches for specific (object) bucket permissions
+   * @param {string|string[]} [params.userId] Optional string or array of uuids representing the user
+   * @param {string|string[]} [params.bucketId]
+   * @returns {Promise<object>} The result of running the find operation
+  */
+  getObjectIdsWithBucket: async (userId, bucketId) => {
+    return ObjectPermission.query()
+      .select('objectId')
+      .distinct('userId')
+      .joinRelated('object')
+      .modify('filterUserId', userId)
+      .modify('filterBucketId', bucketId)
+      .whereNotNull('objectId')
+      .then(response => response.map(entry => entry.objectId));
+  },
+
+  /**
    * @function removePermissions
    * Deletes object permissions for a user
    * @param {string} objId The objectId uuid

--- a/app/src/validators/objectPermission.js
+++ b/app/src/validators/objectPermission.js
@@ -6,6 +6,7 @@ const schema = {
   searchPermissions: {
     query: Joi.object({
       bucketId: scheme.guid,
+      bucketPerms: type.truthy,
       userId: scheme.guid,
       objId: scheme.guid,
       permCode: scheme.permCode


### PR DESCRIPTION
Extending get object permissions endpoint by adding 'bucketPerms' flag to include all object permissions within bucket if flag set to true.

<!-- Provide a general summary of your changes in the Title above -->
# Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [ ] I have checked that unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->