### PR TITLE
Minor Helm Chart Maintenance and Patroni Bump

### DIFF
--- a/.github/environments/values.pr.yaml
+++ b/.github/environments/values.pr.yaml
@@ -11,7 +11,7 @@ patroni:
       cpu: 250m
       memory: 384Mi
     requests:
-      cpu: 50m
+      cpu: 20m
       memory: 192Mi
   persistentVolume:
     enabled: false

--- a/charts/coms/Chart.yaml
+++ b/charts/coms/Chart.yaml
@@ -3,7 +3,7 @@ name: common-object-management-service
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.7
+version: 0.0.8
 kubeVersion: ">= 1.13.0"
 description: A microservice for managing access control to S3 Objects
 # A chart can be either an 'application' or a 'library' chart.
@@ -28,7 +28,7 @@ sources:
   - https://github.com/bcgov/common-object-management-service
 dependencies:
   - name: patroni
-    version: ~0.0.3
+    version: ~0.0.4
     repository: https://bcgov.github.io/nr-patroni-chart
     condition: patroni.enabled
     tags:

--- a/charts/coms/templates/networkpolicy.yaml
+++ b/charts/coms/templates/networkpolicy.yaml
@@ -1,4 +1,25 @@
-{{- if and .Values.networkPolicy.enabled .Values.patroni.enabled }}
+{{- if .Values.networkPolicy.enabled }}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-openshift-ingress-to-{{ include "coms.fullname" . }}-app
+  labels:
+    {{- include "coms.labels" . | nindent 4 }}
+spec:
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              network.openshift.io/policy-group: ingress
+        - podSelector:
+            matchLabels: {{ include "coms.selectorLabels" . | nindent 14 }}
+      ports:
+        - port: {{ default "8080" .Values.config.configMap.SERVER_PORT | atoi }}
+          protocol: TCP
+  podSelector:
+    matchLabels: {{- include "coms.selectorLabels" . | nindent 6 }}
+{{- if .Values.patroni.enabled }}
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -32,4 +53,5 @@ spec:
           protocol: TCP
   podSelector:
     matchLabels: {{ include "patroni.selectorLabels" .Subcharts.patroni | nindent 6 }}
+{{- end }}
 {{- end }}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

<!-- Describe your changes in detail -->
This PR focuses on getting the latest Patroni chart installed (includes the OCP 4.11 privilege escalation fix) and introduces an explicit network policy for receiving traffic from the openshift load balancer.

- af99137 Version bump patroni chart to 0.0.4
- 2344961 Add explicit openshift ingress to app network policy

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
[SHOWCASE-3016](https://apps.nrs.gov.bc.ca/int/jira/browse/SHOWCASE-3016)

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
New feature (non-breaking change which adds functionality)
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->