### PR TITLE
Extend object bucketPerms filtering

### DIFF
--- a/app/src/controllers/objectPermission.js
+++ b/app/src/controllers/objectPermission.js
@@ -22,18 +22,18 @@ const controller = {
     try {
       const bucketIds = utils.mixedQueryToArray(req.query.bucketId);
       const objIds = utils.mixedQueryToArray(req.query.objId);
-      const userId = req.query.userId;
+      const permCodes = utils.mixedQueryToArray(req.query.permCode);
+      const userIds = utils.mixedQueryToArray(req.query.userId);
       const result = await objectPermissionService.searchPermissions({
         bucketId: bucketIds ? bucketIds.map(id => utils.addDashesToUuid(id)) : bucketIds,
         objId: objIds ? objIds.map(id => utils.addDashesToUuid(id)) : objIds,
-        userId: userId ? utils.addDashesToUuid(userId) : userId,
-        permCode: utils.mixedQueryToArray(req.query.permCode)
+        userId: userIds ? userIds.map(id => utils.addDashesToUuid(id)) : userIds,
+        permCode: permCodes
       });
       const response = utils.groupByObject('objectId', 'permissions', result);
 
       if (utils.isTruthy(req.query.bucketPerms)) {
-        const objectIds = await objectPermissionService.getObjectIdsWithBucket(userId, bucketIds);
-
+        const objectIds = await objectPermissionService.getObjectIdsWithBucket(userIds, bucketIds, permCodes);
         objectIds.forEach(objectId => {
           if (!response.map(r => r.objectId).includes(objectId)) {
             response.push({

--- a/app/src/validators/objectPermission.js
+++ b/app/src/validators/objectPermission.js
@@ -10,7 +10,7 @@ const schema = {
       userId: scheme.guid,
       objId: scheme.guid,
       permCode: scheme.permCode
-    }).min(1)
+    })
   },
 
   listPermissions: {

--- a/app/tests/unit/controllers/objectPermission.spec.js
+++ b/app/tests/unit/controllers/objectPermission.spec.js
@@ -34,7 +34,7 @@ describe('searchPermissions', () => {
     const res = mockResponse();
     await controller.searchPermissions(req, res, next);
     expect(searchPermissionsSpy).toHaveBeenCalledTimes(1);
-    expect(searchPermissionsSpy).toHaveBeenCalledWith({ bucketId: [req.query.bucketId], objId: [req.query.objId], userId: req.query.userId, permCode: [req.query.permCode] });
+    expect(searchPermissionsSpy).toHaveBeenCalledWith({ bucketId: [req.query.bucketId], objId: [req.query.objId], userId: [req.query.userId], permCode: [req.query.permCode] });
     expect(res.status).toHaveBeenCalledWith(200);
     expect(res.json).toHaveBeenCalledWith([]);
     expect(next).toHaveBeenCalledTimes(0);

--- a/app/tests/unit/validators/objectPermission.spec.js
+++ b/app/tests/unit/validators/objectPermission.spec.js
@@ -10,17 +10,6 @@ describe('searchPermissions', () => {
   describe('query', () => {
     const query = schema.searchPermissions.query.describe();
 
-    it('requires at least 1 parameter', () => {
-      expect(query.rules).toEqual(expect.arrayContaining([
-        expect.objectContaining({
-          name: 'min',
-          args: {
-            limit: 1
-          }
-        })
-      ]));
-    });
-
     describe('userId', () => {
       const userId = query.keys.userId;
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

https://apps.nrs.gov.bc.ca/int/jira/browse/SHOWCASE-3034

background info:
when doing a search for object permissions (GET /object/Permissions?bucketPerms=true)
if we pass bucketPerms=true, we also return objects with bucket-level perms (we have been describing these as 'implicit' or 'inherited' permissions).

user story:
a client app (eg bcbox) user can get 'my files' by calling this coms endpoint. But we should also allow the request to filter OPTIONALLY by bucketId, permcode and userId.

Acceptance criteria:
- remove .min(1) from validation layer
- pass permCodes query param value to getObjectIdsWithBucket() 
- modify getObjectIdsWithBucket() query to filter on bucketId, userId and permCode.
-update unite tests

note: api spec update will be done later this sprint along with other changes

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->