### PR TITLE
PrivacyMask implementation

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -75,6 +75,13 @@ if (state.authMode === AuthMode.OIDCAUTH || state.authMode === AuthMode.FULLAUTH
   app.use(keycloak.middleware());
 }
 
+// Application privacy Mode mode
+if (config.has('server.privacyMask')) {
+  log.info('Running COMS with strict content privacy masking');
+} else {
+  log.info('Running COMS with permissive content privacy masking');
+}
+
 // Block requests until service is ready
 app.use((_req, res, next) => {
   if (state.shutdown) {
@@ -98,6 +105,7 @@ apiRouter.get('/', (_req, res) => {
         hasDb: config.has('db.enabled'),
         name: process.env.npm_package_name,
         nodeVersion: process.version,
+        privacyMask: config.has('server.privacyMask'),
         version: process.env.npm_package_version
       },
       endpoints: ['/api/v1'],

--- a/app/config/custom-environment-variables.json
+++ b/app/config/custom-environment-variables.json
@@ -10,8 +10,7 @@
     "host": "DB_HOST",
     "username": "DB_USERNAME",
     "password": "DB_PASSWORD",
-    "port": "DB_PORT",
-    "privacyMask": "DB_PRIVACY_MASK"
+    "port": "DB_PORT"
   },
   "keycloak": {
     "enabled": "KC_ENABLED",
@@ -35,6 +34,7 @@
     "logFile": "SERVER_LOGFILE",
     "logLevel": "SERVER_LOGLEVEL",
     "passphrase": "SERVER_PASSPHRASE",
-    "port": "SERVER_PORT"
+    "port": "SERVER_PORT",
+    "privacyMask": "SERVER_PRIVACY_MASK"
   }
 }

--- a/app/config/custom-environment-variables.json
+++ b/app/config/custom-environment-variables.json
@@ -10,7 +10,8 @@
     "host": "DB_HOST",
     "username": "DB_USERNAME",
     "password": "DB_PASSWORD",
-    "port": "DB_PORT"
+    "port": "DB_PORT",
+    "privacyMask": "DB_PRIVACY_MASK"
   },
   "keycloak": {
     "enabled": "KC_ENABLED",

--- a/app/src/components/utils.js
+++ b/app/src/components/utils.js
@@ -195,15 +195,6 @@ const utils = {
   },
 
   /**
-   * @function privacyMask
-   * Gets privacyMask configuration
-   * @returns {Boolean} Is privacyMask enabled
-   */
-  async getPrivacyMask() {
-    return config.has('db.privacyMask') ? true : false;
-  },
-
-  /**
    * @function groupByObject
    * Re-structure array of nested objects
    * @see {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/reduce#grouping_objects_by_a_property}

--- a/app/src/components/utils.js
+++ b/app/src/components/utils.js
@@ -195,6 +195,15 @@ const utils = {
   },
 
   /**
+   * @function privacyMask
+   * Gets privacyMask configuration
+   * @returns {Boolean} Is privacyMask enabled
+   */
+  async getPrivacyMask() {
+    return config.has('db.privacyMask') ? true : false;
+  },
+
+  /**
    * @function groupByObject
    * Re-structure array of nested objects
    * @see {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/reduce#grouping_objects_by_a_property}

--- a/app/src/controllers/metadata.js
+++ b/app/src/controllers/metadata.js
@@ -1,8 +1,7 @@
 const config = require('config');
-const { NIL: SYSTEM_USER } = require('uuid');
 const errorToProblem = require('../components/errorToProblem');
-const { getCurrentIdentity, getMetadata } = require('../components/utils');
-const { metadataService, userService } = require('../services');
+const { getMetadata } = require('../components/utils');
+const { metadataService } = require('../services');
 
 const SERVICE = 'MetadataService';
 
@@ -22,12 +21,9 @@ const controller = {
     try {
       const metadata = getMetadata(req.headers);
       const params = {
-        metadata: metadata && Object.keys(metadata).length ? metadata : undefined
+        metadata: metadata && Object.keys(metadata).length ? metadata : undefined,
+        privacyMask : req.currentUser.authType !== 'BASIC' ? config.has('server.privacyMask') : false
       };
-      // if scoping to current user permissions on objects
-      if (config.has('server.privacyMask')) {
-        params.userId = await userService.getCurrentUserId(getCurrentIdentity(req.currentUser, SYSTEM_USER));
-      }
 
       const response = await metadataService.searchMetadata(params);
       res.status(200).json(response);

--- a/app/src/controllers/metadata.js
+++ b/app/src/controllers/metadata.js
@@ -1,6 +1,8 @@
+const config = require('config');
+const { NIL: SYSTEM_USER } = require('uuid');
 const errorToProblem = require('../components/errorToProblem');
-const { getMetadata } = require('../components/utils');
-const { metadataService } = require('../services');
+const { getCurrentIdentity, getMetadata } = require('../components/utils');
+const { metadataService, userService } = require('../services');
 
 const SERVICE = 'MetadataService';
 
@@ -22,6 +24,10 @@ const controller = {
       const params = {
         metadata: metadata && Object.keys(metadata).length ? metadata : undefined
       };
+      // if scoping to current user permissions on objects
+      if (config.has('server.privacyMask')) {
+        params.userId = await userService.getCurrentUserId(getCurrentIdentity(req.currentUser, SYSTEM_USER));
+      }
 
       const response = await metadataService.searchMetadata(params);
       res.status(200).json(response);

--- a/app/src/controllers/object.js
+++ b/app/src/controllers/object.js
@@ -15,6 +15,7 @@ const {
   getKeyValue,
   getMetadata,
   getPath,
+  getPrivacyMask,
   joinPath,
   isTruthy,
   mixedQueryToArray,
@@ -468,7 +469,10 @@ const controller = {
         objId: objIds ? objIds.map(id => addDashesToUuid(id)) : objIds,
         metadata: metadata && Object.keys(metadata).length ? metadata : undefined
       };
-
+      // if scoping to current user permissions on objects
+      if (getPrivacyMask) {
+        params.userId = await userService.getCurrentUserId(getCurrentIdentity(req.currentUser, SYSTEM_USER));
+      }
       const response = await metadataService.fetchMetadataForObject(params);
       res.status(200).json(response);
     } catch (error) {
@@ -492,7 +496,10 @@ const controller = {
         objectIds: objIds ? objIds.map(id => addDashesToUuid(id)) : objIds,
         tagset: tagset && Object.keys(tagset).length ? tagset : undefined,
       };
-
+      // if scoping to current user permissions on objects
+      if (getPrivacyMask) {
+        params.userId = await userService.getCurrentUserId(getCurrentIdentity(req.currentUser, SYSTEM_USER));
+      }
       const response = await tagService.fetchTagsForObject(params);
       res.status(200).json(response);
     } catch (error) {
@@ -732,7 +739,10 @@ const controller = {
         deleteMarker: isTruthy(req.query.deleteMarker),
         latest: isTruthy(req.query.latest)
       };
-
+      // if scoping to current user permissions on objects
+      if (getPrivacyMask) {
+        params.userId = await userService.getCurrentUserId(getCurrentIdentity(req.currentUser, SYSTEM_USER));
+      }
       const response = await objectService.searchObjects(params);
       res.status(200).json(response);
     } catch (error) {

--- a/app/src/controllers/object.js
+++ b/app/src/controllers/object.js
@@ -1,5 +1,6 @@
 const Problem = require('api-problem');
 const busboy = require('busboy');
+const config = require('config');
 const cors = require('cors');
 const { v4: uuidv4, NIL: SYSTEM_USER } = require('uuid');
 
@@ -15,7 +16,6 @@ const {
   getKeyValue,
   getMetadata,
   getPath,
-  getPrivacyMask,
   joinPath,
   isTruthy,
   mixedQueryToArray,
@@ -470,8 +470,8 @@ const controller = {
         metadata: metadata && Object.keys(metadata).length ? metadata : undefined
       };
       // if scoping to current user permissions on objects
-      if (getPrivacyMask) {
-        params.userId = await userService.getCurrentUserId(getCurrentIdentity(req.currentUser, SYSTEM_USER));
+      if (config.has('server.privacyMask')) {
+        params.userId = await userService.getCurrentUserId(getCurrentIdentity(req.currentUser, undefined));
       }
       const response = await metadataService.fetchMetadataForObject(params);
       res.status(200).json(response);
@@ -497,8 +497,8 @@ const controller = {
         tagset: tagset && Object.keys(tagset).length ? tagset : undefined,
       };
       // if scoping to current user permissions on objects
-      if (getPrivacyMask) {
-        params.userId = await userService.getCurrentUserId(getCurrentIdentity(req.currentUser, SYSTEM_USER));
+      if (config.has('server.privacyMask')) {
+        params.userId = await userService.getCurrentUserId(getCurrentIdentity(req.currentUser, undefined));
       }
       const response = await tagService.fetchTagsForObject(params);
       res.status(200).json(response);
@@ -740,8 +740,8 @@ const controller = {
         latest: isTruthy(req.query.latest)
       };
       // if scoping to current user permissions on objects
-      if (getPrivacyMask) {
-        params.userId = await userService.getCurrentUserId(getCurrentIdentity(req.currentUser, SYSTEM_USER));
+      if (config.has('server.privacyMask')) {
+        params.userId = await userService.getCurrentUserId(getCurrentIdentity(req.currentUser, undefined));
       }
       const response = await objectService.searchObjects(params);
       res.status(200).json(response);

--- a/app/src/controllers/object.js
+++ b/app/src/controllers/object.js
@@ -471,7 +471,7 @@ const controller = {
       };
       // if scoping to current user permissions on objects
       if (config.has('server.privacyMask')) {
-        params.userId = await userService.getCurrentUserId(getCurrentIdentity(req.currentUser, undefined));
+        params.userId = await userService.getCurrentUserId(getCurrentIdentity(req.currentUser, SYSTEM_USER));
       }
       const response = await metadataService.fetchMetadataForObject(params);
       res.status(200).json(response);
@@ -498,7 +498,7 @@ const controller = {
       };
       // if scoping to current user permissions on objects
       if (config.has('server.privacyMask')) {
-        params.userId = await userService.getCurrentUserId(getCurrentIdentity(req.currentUser, undefined));
+        params.userId = await userService.getCurrentUserId(getCurrentIdentity(req.currentUser, SYSTEM_USER));
       }
       const response = await tagService.fetchTagsForObject(params);
       res.status(200).json(response);
@@ -741,7 +741,7 @@ const controller = {
       };
       // if scoping to current user permissions on objects
       if (config.has('server.privacyMask')) {
-        params.userId = await userService.getCurrentUserId(getCurrentIdentity(req.currentUser, undefined));
+        params.userId = await userService.getCurrentUserId(getCurrentIdentity(req.currentUser, SYSTEM_USER));
       }
       const response = await objectService.searchObjects(params);
       res.status(200).json(response);

--- a/app/src/controllers/tag.js
+++ b/app/src/controllers/tag.js
@@ -1,8 +1,6 @@
 const config = require('config');
-const { NIL: SYSTEM_USER } = require('uuid');
 const errorToProblem = require('../components/errorToProblem');
-const { getCurrentIdentity } = require('../components/utils');
-const { tagService, userService } = require('../services');
+const { tagService } = require('../services');
 
 const SERVICE = 'TagService';
 
@@ -24,11 +22,8 @@ const controller = {
       const tagging = req.query.tagset;
       const params = {
         tag: tagging && Object.keys(tagging).length ? tagging : undefined,
+        privacyMask : req.currentUser.authType !== 'BASIC' ? config.has('server.privacyMask') : false
       };
-      // if scoping to current user permissions on objects
-      if (config.has('server.privacyMask')) {
-        params.userId = await userService.getCurrentUserId(getCurrentIdentity(req.currentUser, SYSTEM_USER));
-      }
 
       const response = await tagService.searchTags(params);
       res.status(200).json(response);

--- a/app/src/controllers/tag.js
+++ b/app/src/controllers/tag.js
@@ -1,5 +1,8 @@
+const config = require('config');
+const { NIL: SYSTEM_USER } = require('uuid');
 const errorToProblem = require('../components/errorToProblem');
-const { tagService } = require('../services');
+const { getCurrentIdentity } = require('../components/utils');
+const { tagService, userService } = require('../services');
 
 const SERVICE = 'TagService';
 
@@ -22,6 +25,10 @@ const controller = {
       const params = {
         tag: tagging && Object.keys(tagging).length ? tagging : undefined,
       };
+      // if scoping to current user permissions on objects
+      if (config.has('server.privacyMask')) {
+        params.userId = await userService.getCurrentUserId(getCurrentIdentity(req.currentUser, SYSTEM_USER));
+      }
 
       const response = await tagService.searchTags(params);
       res.status(200).json(response);

--- a/app/src/controllers/version.js
+++ b/app/src/controllers/version.js
@@ -1,6 +1,6 @@
-const { NIL: SYSTEM_USER } = require('uuid');
+const config = require('config');
 const errorToProblem = require('../components/errorToProblem');
-const { addDashesToUuid, getCurrentIdentity, getMetadata, mixedQueryToArray, getPrivacyMask } = require('../components/utils');
+const { addDashesToUuid, getCurrentIdentity, getMetadata, mixedQueryToArray } = require('../components/utils');
 const { metadataService, tagService, userService } = require('../services');
 
 const SERVICE = 'VersionService';
@@ -27,8 +27,8 @@ const controller = {
         metadata: metadata && Object.keys(metadata).length ? metadata : undefined,
       };
       // if scoping to current user permissions on objects
-      if (getPrivacyMask) {
-        params.userId = await userService.getCurrentUserId(getCurrentIdentity(req.currentUser, SYSTEM_USER));
+      if (config.has('server.privacyMask')) {
+        params.userId = await userService.getCurrentUserId(getCurrentIdentity(req.currentUser, undefined));
       }
       const response = await metadataService.fetchMetadataForVersion(params);
       res.status(200).json(response);
@@ -55,8 +55,8 @@ const controller = {
         tags: tagging && Object.keys(tagging).length ? tagging : undefined,
       };
       // if scoping to current user permissions on objects
-      if (getPrivacyMask) {
-        params.userId = await userService.getCurrentUserId(getCurrentIdentity(req.currentUser, SYSTEM_USER));
+      if (config.has('server.privacyMask')) {
+        params.userId = await userService.getCurrentUserId(getCurrentIdentity(req.currentUser, undefined));
       }
       const response = await tagService.fetchTagsForVersion(params);
       res.status(200).json(response);

--- a/app/src/controllers/version.js
+++ b/app/src/controllers/version.js
@@ -1,4 +1,5 @@
 const config = require('config');
+const { NIL: SYSTEM_USER } = require('uuid');
 const errorToProblem = require('../components/errorToProblem');
 const { addDashesToUuid, getCurrentIdentity, getMetadata, mixedQueryToArray } = require('../components/utils');
 const { metadataService, tagService, userService } = require('../services');
@@ -28,7 +29,7 @@ const controller = {
       };
       // if scoping to current user permissions on objects
       if (config.has('server.privacyMask')) {
-        params.userId = await userService.getCurrentUserId(getCurrentIdentity(req.currentUser, undefined));
+        params.userId = await userService.getCurrentUserId(getCurrentIdentity(req.currentUser, SYSTEM_USER));
       }
       const response = await metadataService.fetchMetadataForVersion(params);
       res.status(200).json(response);
@@ -56,7 +57,7 @@ const controller = {
       };
       // if scoping to current user permissions on objects
       if (config.has('server.privacyMask')) {
-        params.userId = await userService.getCurrentUserId(getCurrentIdentity(req.currentUser, undefined));
+        params.userId = await userService.getCurrentUserId(getCurrentIdentity(req.currentUser, SYSTEM_USER));
       }
       const response = await tagService.fetchTagsForVersion(params);
       res.status(200).json(response);

--- a/app/src/controllers/version.js
+++ b/app/src/controllers/version.js
@@ -1,6 +1,7 @@
+const { NIL: SYSTEM_USER } = require('uuid');
 const errorToProblem = require('../components/errorToProblem');
-const { addDashesToUuid, getMetadata, mixedQueryToArray } = require('../components/utils');
-const { metadataService, tagService } = require('../services');
+const { addDashesToUuid, getCurrentIdentity, getMetadata, mixedQueryToArray, getPrivacyMask } = require('../components/utils');
+const { metadataService, tagService, userService } = require('../services');
 
 const SERVICE = 'VersionService';
 
@@ -25,7 +26,10 @@ const controller = {
         versionIds: versionIds ? versionIds.map(id => addDashesToUuid(id)) : versionIds,
         metadata: metadata && Object.keys(metadata).length ? metadata : undefined,
       };
-
+      // if scoping to current user permissions on objects
+      if (getPrivacyMask) {
+        params.userId = await userService.getCurrentUserId(getCurrentIdentity(req.currentUser, SYSTEM_USER));
+      }
       const response = await metadataService.fetchMetadataForVersion(params);
       res.status(200).json(response);
     } catch (e) {
@@ -50,7 +54,10 @@ const controller = {
         versionIds: versionIds ? versionIds.map(id => addDashesToUuid(id)) : versionIds,
         tags: tagging && Object.keys(tagging).length ? tagging : undefined,
       };
-
+      // if scoping to current user permissions on objects
+      if (getPrivacyMask) {
+        params.userId = await userService.getCurrentUserId(getCurrentIdentity(req.currentUser, SYSTEM_USER));
+      }
       const response = await tagService.fetchTagsForVersion(params);
       res.status(200).json(response);
     } catch (e) {

--- a/app/src/db/models/tables/metadata.js
+++ b/app/src/db/models/tables/metadata.js
@@ -35,9 +35,24 @@ class Metadata extends Model {
 
   static get modifiers() {
     return {
+      filterKey(query, value) {
+        const subqueries = [];
+        if (value.metadata && Object.keys(value.metadata).length) {
+          Object.entries(value.metadata).forEach(metadata => {
+            const q = Metadata.query().select('metadata.id').where('key', 'ilike', `%${metadata[0]}%`);
+            subqueries.push(q);
+          });
+        }
+        if (subqueries.length) {
+          query
+            .whereIn('metadata.id', builder => {
+              builder.intersect(subqueries);
+            });
+        }
+      },
+
       filterKeyValue(query, value) {
         const subqueries = [];
-
         if (value.metadata && Object.keys(value.metadata).length) {
           Object.entries(value.metadata).forEach(([key, val]) => {
             const q = Metadata.query().select('metadata.id').where('key', 'ilike', `%${key}%`);
@@ -45,7 +60,6 @@ class Metadata extends Model {
             subqueries.push(q);
           });
         }
-
         if (subqueries.length) {
           query
             .whereIn('metadata.id', builder => {

--- a/app/src/db/models/tables/metadata.js
+++ b/app/src/db/models/tables/metadata.js
@@ -40,7 +40,7 @@ class Metadata extends Model {
 
         if (value.metadata && Object.keys(value.metadata).length) {
           Object.entries(value.metadata).forEach(([key, val]) => {
-            const q = Metadata.query().select('id').where('key', 'ilike', `%${key}%`);
+            const q = Metadata.query().select('metadata.id').where('key', 'ilike', `%${key}%`);
             if (val.length) q.where('value', 'ilike', `%${val}%`);
             subqueries.push(q);
           });
@@ -48,7 +48,7 @@ class Metadata extends Model {
 
         if (subqueries.length) {
           query
-            .whereIn('id', builder => {
+            .whereIn('metadata.id', builder => {
               builder.intersect(subqueries);
             });
         }

--- a/app/src/db/models/tables/objectModel.js
+++ b/app/src/db/models/tables/objectModel.js
@@ -159,22 +159,23 @@ class ObjectModel extends Timestamps(Model) {
             });
         }
       },
-      hasPermission(query, value) {
-        if (value) {
+      // TODO: consider handling an array of permCodes
+      hasPermission(query, userId, permCode) {
+        if (userId && permCode) {
           query
-            // .allowGraph('[objectPermission, bucketPermission]')
+            .allowGraph('[objectPermission, bucketPermission]')
             .withGraphJoined('[objectPermission, bucketPermission]')
             .whereIn('objectPermission.objectId', query => {
               query
                 .distinct('objectPermission.objectId')
-                .where('objectPermission.permCode', 'READ')
-                .where('objectPermission.userId', value);
+                .where('objectPermission.permCode', permCode)
+                .where('objectPermission.userId', userId);
             })
             .orWhereIn('object.bucketId', query => {
               query
                 .distinct('bucketPermission.bucketId')
-                .where('bucketPermission.permCode', 'READ')
-                .where('bucketPermission.userId', value);
+                .where('bucketPermission.permCode', permCode)
+                .where('bucketPermission.userId', userId);
             });
         }
       }

--- a/app/src/db/models/tables/tag.js
+++ b/app/src/db/models/tables/tag.js
@@ -36,9 +36,24 @@ class Tag extends Model {
 
   static get modifiers() {
     return {
+      filterKey(query, value) {
+        const subqueries = [];
+        if (value.tag && Object.keys(value.tag).length) {
+          Object.entries(value.tag).forEach(tag => {
+            const q = Tag.query().select('tag.id').where('key', 'ilike', `%${tag[0]}%`);
+            subqueries.push(q);
+          });
+        }
+        if (subqueries.length) {
+          query
+            .whereIn('tag.id', builder => {
+              builder.intersect(subqueries);
+            });
+        }
+      },
+
       filterKeyValue(query, value) {
         const subqueries = [];
-
         if (value.tag && Object.keys(value.tag).length) {
           Object.entries(value.tag).forEach(([key, val]) => {
             const q = Tag.query().select('tag.id').where('key', 'ilike', `%${key}%`);
@@ -46,7 +61,6 @@ class Tag extends Model {
             subqueries.push(q);
           });
         }
-
         if (subqueries.length) {
           query
             .whereIn('tag.id', builder => {

--- a/app/src/db/models/tables/tag.js
+++ b/app/src/db/models/tables/tag.js
@@ -41,7 +41,7 @@ class Tag extends Model {
 
         if (value.tag && Object.keys(value.tag).length) {
           Object.entries(value.tag).forEach(([key, val]) => {
-            const q = Tag.query().select('id').where('key', 'ilike', `%${key}%`);
+            const q = Tag.query().select('tag.id').where('key', 'ilike', `%${key}%`);
             if (val.length) q.where('value', 'ilike', `%${val}%`);
             subqueries.push(q);
           });
@@ -49,7 +49,7 @@ class Tag extends Model {
 
         if (subqueries.length) {
           query
-            .whereIn('id', builder => {
+            .whereIn('tag.id', builder => {
               builder.intersect(subqueries);
             });
         }

--- a/app/src/services/metadata.js
+++ b/app/src/services/metadata.js
@@ -180,7 +180,7 @@ const service = {
       // match on objId parameter
       .modify('filterIds', params.objId)
       // scope to objects that user(s) has READ permission for either at object or bucket-level
-      .modify('hasPermission', params.userId)
+      .modify('hasPermission', params.userId, 'READ')
       // re-structure result like: [{ objectId: abc, metadata: [{ key: a, value: b }] }]
       .then(result => result.map(row => {
         return {
@@ -216,10 +216,7 @@ const service = {
           query
             .allowGraph('object.[objectPermission, bucketPermission]')
             .withGraphJoined('object.[objectPermission, bucketPermission]')
-            .modifyGraph('object', query => {
-              query
-                .modify('hasPermission', params.userId);
-            })
+            .modifyGraph('object', query => { query.modify('hasPermission', params.userId, 'READ'); })
             .whereNotNull('object.id');
         }
       })
@@ -227,8 +224,8 @@ const service = {
       .orderBy('version.createdAt', 'desc')
       .then(result => result.map(row => {
         // eslint-disable-next-line no-unused-vars
-        const { object, ...data} = row;
-        return data ;
+        const { object, ...data } = row;
+        return data;
       }));
   },
 

--- a/app/src/services/metadata.js
+++ b/app/src/services/metadata.js
@@ -239,20 +239,18 @@ const service = {
    */
   searchMetadata: (params) => {
     return Metadata.query()
-      .modify('filterKeyValue', { metadata: params.metadata })
-      // filter to include only metadata on objects where user has READ permission at object or bucket-level
       .modify((query) => {
-        if (params.userId) {
+        if (params.privacyMask) {
           query
-            .allowGraph('version.object.[objectPermission, bucketPermission]')
-            .withGraphJoined('version.object.[objectPermission, bucketPermission]')
-            .modifyGraph('version.object', query => { query.modify('hasPermission', params.userId, 'READ'); })
-            .whereNotNull('version:object.id');
+            .select('key')
+            .modify('filterKey', { metadata: params.metadata });
         }
-      })
-      .then(result => result.map(row => {
-        return { key: row.key, value: row.value };
-      }));
+        else {
+          query
+            .select('key', 'value')
+            .modify('filterKeyValue', { metadata: params.metadata });
+        }
+      });
   },
 };
 

--- a/app/src/services/object.js
+++ b/app/src/services/object.js
@@ -127,7 +127,7 @@ const service = {
         metadata: params.metadata,
         tag: params.tag
       })
-      .modify('hasPermission', params.userId)
+      .modify('hasPermission', params.userId, 'READ')
       .then(result => result.map(row => {
         // eslint-disable-next-line no-unused-vars
         const { objectPermission, bucketPermission, version, ...object } = row;

--- a/app/src/services/object.js
+++ b/app/src/services/object.js
@@ -119,7 +119,6 @@ const service = {
       .modify('filterPath', params.path)
       .modify('filterPublic', params.public)
       .modify('filterActive', params.active)
-      .modify('filterUserId', params.userId)
       .modify('filterMimeType', params.mimeType)
       .modify('filterDeleteMarker', params.deleteMarker)
       .modify('filterLatest', params.latest)
@@ -128,9 +127,10 @@ const service = {
         metadata: params.metadata,
         tag: params.tag
       })
+      .modify('hasPermission', params.userId)
       .then(result => result.map(row => {
         // eslint-disable-next-line no-unused-vars
-        const { objectPermission, version, ...object } = row;
+        const { objectPermission, bucketPermission, version, ...object } = row;
         return object;
       }));
   },

--- a/app/src/services/tag.js
+++ b/app/src/services/tag.js
@@ -254,7 +254,7 @@ const service = {
       // match on objectIds parameter
       .modify('filterIds', params.objectIds)
       // scope to objects that user(s) has READ permission for either at object or bucket-level
-      .modify('hasPermission', params.userId)
+      .modify('hasPermission', params.userId, 'READ')
       // re-structure result like: [{ objectId: abc, tagset: [{ key: a, value: b }] }]
       .then(result => result.map(row => {
         return {
@@ -290,18 +290,15 @@ const service = {
           query
             .allowGraph('object.[objectPermission, bucketPermission]')
             .withGraphJoined('object.[objectPermission, bucketPermission]')
-            .modifyGraph('object', query => {
-              query
-                .modify('hasPermission', params.userId);
-            })
+            .modifyGraph('object', query => { query.modify('hasPermission', params.userId, 'READ'); })
             .whereNotNull('object.id');
         }
       })
       .orderBy('version.createdAt', 'desc')
       .then(result => result.map(row => {
         // eslint-disable-next-line no-unused-vars
-        const { object, ...data} = row;
-        return data ;
+        const { object, ...data } = row;
+        return data;
       }));
   },
   /**

--- a/app/src/validators/object.js
+++ b/app/src/validators/object.js
@@ -68,7 +68,7 @@ const schema = {
   fetchMetadata: {
     headers: type.metadata(),
     query: Joi.object({
-      objId: scheme.guid.required()
+      objId: scheme.guid
     })
   },
 
@@ -136,7 +136,7 @@ const schema = {
 
   fetchTags: {
     query: Joi.object({
-      objId: scheme.guid.required(),
+      objId: scheme.guid,
       tagset: type.tagset(),
     })
   },

--- a/app/src/validators/version.js
+++ b/app/src/validators/version.js
@@ -6,13 +6,13 @@ const schema = {
   fetchMetadata: {
     headers: type.metadata(),
     query: Joi.object({
-      versionId: scheme.guid.required(),
+      versionId: scheme.guid,
     })
   },
 
   fetchTags: {
     query: Joi.object({
-      versionId: scheme.guid.required(),
+      versionId: scheme.guid,
       tagset: type.tagset(),
     })
   },

--- a/app/tests/unit/controllers/metadata.spec.js
+++ b/app/tests/unit/controllers/metadata.spec.js
@@ -23,14 +23,13 @@ afterEach(() => {
 describe('searchMetadata', () => {
   // mock service calls
   const metadataSearchMetadataSpy = jest.spyOn(metadataService, 'searchMetadata');
-
   const next = jest.fn();
 
   it('should return all metadata with no params', async () => {
     // request object
     const req = {
-      headers: {},
-      query: {}
+      currentUser: { authType: 'BEARER' },
+      headers: {}
     };
 
     const GoodResponse = [{
@@ -57,8 +56,8 @@ describe('searchMetadata', () => {
   it('should return only matching metadata', async () => {
     // request object
     const req = {
-      headers: { 'x-amz-meta-foo': '' },
-      query: {}
+      currentUser: { authType: 'BEARER' },
+      headers: { 'x-amz-meta-foo': '' }
     };
 
     const GoodResponse = [{

--- a/app/tests/unit/controllers/tag.spec.js
+++ b/app/tests/unit/controllers/tag.spec.js
@@ -33,6 +33,7 @@ describe('searchTags', () => {
   it('should return all tags with no params', async () => {
     // request object
     const req = {
+      currentUser: { authType: 'BEARER' },
       headers: {},
       query: {}
     };
@@ -61,6 +62,7 @@ describe('searchTags', () => {
   it('should return only matching tags', async () => {
     // request object
     const req = {
+      currentUser: { authType: 'BEARER' },
       headers: {},
       query: {
         tagset: {

--- a/app/tests/unit/validators/version.spec.js
+++ b/app/tests/unit/validators/version.spec.js
@@ -20,7 +20,7 @@ describe('fetchMetadata', () => {
       const versionId = query.keys.versionId;
 
       it('is the expected schema', () => {
-        expect(versionId).toEqual(scheme.guid.required().describe());
+        expect(versionId).toEqual(scheme.guid.describe());
       });
     });
   });
@@ -37,7 +37,7 @@ describe('fetchTags', () => {
       const versionId = query.keys.versionId;
 
       it('is the expected schema', () => {
-        expect(versionId).toEqual(scheme.guid.required().describe());
+        expect(versionId).toEqual(scheme.guid.describe());
       });
     });
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

This PR adds a 'privacyMask' config/toggle that will scope COMS search results to only expose data relating to objects that they have READ permission for.

related tickets (with some discussion in the comments):
endpoints affected - https://apps.nrs.gov.bc.ca/int/jira/browse/SHOWCASE-3020
feature toggle - https://apps.nrs.gov.bc.ca/int/jira/browse/SHOWCASE-3032
sql queries - https://apps.nrs.gov.bc.ca/int/jira/browse/SHOWCASE-3019

I've tried to get the SQL right using Objection/Knex.
The basic pattern is to use withGraphJoined to join the object model and use its hasPermission() modifier.
(ticket 3019 shows raw sql for the `GET /object/tags` scoped to permissions (fetchTagsForObject() in the tag.js service)


## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->