### PR TITLE
Joi validation for implicit permission search

### DIFF
--- a/app/src/validators/bucketPermission.js
+++ b/app/src/validators/bucketPermission.js
@@ -5,11 +5,19 @@ const { Permissions } = require('../components/constants');
 const schema = {
   searchPermissions: {
     query: Joi.object({
-      objectPerms: type.truthy,
-      userId: scheme.guid,
       bucketId: scheme.guid,
-      permCode: scheme.permCode
-    }).min(1)
+      objectPerms: type.truthy,
+      permCode: scheme.permCode,
+      userId: Joi.alternatives()
+        .conditional('objectPerms', {
+          is: true,
+          then: type.uuidv4
+            .required()
+            .messages({
+              'string.guid': 'One userId required when `objectPerms=true`',
+            }),
+          otherwise: scheme.guid })
+    })
   },
 
   listPermissions: {

--- a/app/src/validators/objectPermission.js
+++ b/app/src/validators/objectPermission.js
@@ -7,9 +7,17 @@ const schema = {
     query: Joi.object({
       bucketId: scheme.guid,
       bucketPerms: type.truthy,
-      userId: scheme.guid,
       objId: scheme.guid,
-      permCode: scheme.permCode
+      permCode: scheme.permCode,
+      userId: Joi.alternatives()
+        .conditional('bucketPerms', {
+          is: true,
+          then: type.uuidv4
+            .required()
+            .messages({
+              'string.guid': 'One userId required when `bucketPerms=true`',
+            }),
+          otherwise: scheme.guid })
     })
   },
 

--- a/app/tests/unit/validators/bucketPermission.spec.js
+++ b/app/tests/unit/validators/bucketPermission.spec.js
@@ -1,3 +1,4 @@
+const Joi = require('joi');
 const jestJoi = require('jest-joi');
 expect.extend(jestJoi.matchers);
 
@@ -10,22 +11,20 @@ describe('searchPermissions', () => {
   describe('query', () => {
     const query = schema.searchPermissions.query.describe();
 
-    it('requires at least 1 parameter', () => {
-      expect(query.rules).toEqual(expect.arrayContaining([
-        expect.objectContaining({
-          name: 'min',
-          args: {
-            limit: 1
-          }
-        })
-      ]));
-    });
-
     describe('userId', () => {
       const userId = query.keys.userId;
 
+      // TODO: test against schema in our code instead of recreating object
       it('is the expected schema', () => {
-        expect(userId).toEqual(scheme.guid.describe());
+        expect(userId).toEqual(Joi.alternatives()
+          .conditional('objectPerms', {
+            is: true,
+            then: type.uuidv4
+              .required()
+              .messages({
+                'string.guid': 'One userId required when `objectPerms=true`',
+              }),
+            otherwise: scheme.guid }).describe());
       });
     });
 

--- a/app/tests/unit/validators/objectPermission.spec.js
+++ b/app/tests/unit/validators/objectPermission.spec.js
@@ -1,4 +1,5 @@
 const jestJoi = require('jest-joi');
+const Joi = require('joi');
 expect.extend(jestJoi.matchers);
 
 const { schema } = require('../../../src/validators/objectPermission');
@@ -13,8 +14,17 @@ describe('searchPermissions', () => {
     describe('userId', () => {
       const userId = query.keys.userId;
 
+      // TODO: test against schema in our code instead of recreating object
       it('is the expected schema', () => {
-        expect(userId).toEqual(scheme.guid.describe());
+        expect(userId).toEqual(Joi.alternatives()
+          .conditional('bucketPerms', {
+            is: true,
+            then: type.uuidv4
+              .required()
+              .messages({
+                'string.guid': 'One userId required when `bucketPerms=true`',
+              }),
+            otherwise: scheme.guid }).describe());
       });
     });
 


### PR DESCRIPTION
passing more than one userId param or excluding userId when you are adding objectPerms or bucketPerms=tru, doesnt behave as expected.
This feature could be scoped to only work for a single userId.
see discussion: https://discord.com/channels/689896523848613952/689896524406194236/1077724927941161000

this PR implements:
- Require a single userId query param  when using either objectPerms/bucketPerms = true to include implicit permissions



<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->