### PR TITLE
Object search permissions join

### DIFF
--- a/app/src/db/models/tables/objectModel.js
+++ b/app/src/db/models/tables/objectModel.js
@@ -159,23 +159,27 @@ class ObjectModel extends Timestamps(Model) {
             });
         }
       },
-      // TODO: consider handling an array of permCodes
       hasPermission(query, userId, permCode) {
         if (userId && permCode) {
           query
-            .allowGraph('[objectPermission, bucketPermission]')
-            .withGraphJoined('[objectPermission, bucketPermission]')
-            .whereIn('objectPermission.objectId', query => {
+            .fullOuterJoinRelated('[objectPermission, bucketPermission]')
+            // wrap in WHERE to make contained clauses exclusive of root query
+            .where(query => {
               query
-                .distinct('objectPermission.objectId')
-                .where('objectPermission.permCode', permCode)
-                .where('objectPermission.userId', userId);
-            })
-            .orWhereIn('object.bucketId', query => {
-              query
-                .distinct('bucketPermission.bucketId')
-                .where('bucketPermission.permCode', permCode)
-                .where('bucketPermission.userId', userId);
+                .where(query => {
+                  query
+                    .where({
+                      'objectPermission.permCode': permCode,
+                      'objectPermission.userId': userId
+                    });
+                })
+                .orWhere(query => {
+                  query
+                    .where({
+                      'bucketPermission.permCode': permCode,
+                      'bucketPermission.userId': userId
+                    });
+                });
             });
         }
       }

--- a/app/src/services/metadata.js
+++ b/app/src/services/metadata.js
@@ -175,7 +175,7 @@ const service = {
       .modifyGraph('version.metadata', builder => {
         builder
           .select('key', 'value')
-          .modify('filterKeyValue', { tag: params.metadata });
+          .modify('filterKeyValue', { metadata: params.metadata });
       })
       // match on objId parameter
       .modify('filterIds', params.objId)
@@ -210,12 +210,11 @@ const service = {
       })
       .modify('filterId', params.versionIds)
       // filter by objects that user(s) has READ permission at object or bucket-level
-      // TODO: consider instead doing `.whereIn('version.objectId', <objects with permission>)`
       .modify((query) => {
         if (params.userId) {
           query
-            .allowGraph('object.[objectPermission, bucketPermission]')
-            .withGraphJoined('object.[objectPermission, bucketPermission]')
+            .allowGraph('object')
+            .withGraphJoined('object')
             .modifyGraph('object', query => { query.modify('hasPermission', params.userId, 'READ'); })
             .whereNotNull('object.id');
         }

--- a/app/src/services/object.js
+++ b/app/src/services/object.js
@@ -127,28 +127,7 @@ const service = {
         metadata: params.metadata,
         tag: params.tag
       })
-      .modify((query) => {
-        // if filtering on current user's object/bucket READ permission
-        if (params.userId) {
-          query
-            .joinRelated('[objectPermission, bucketPermission]')
-            .where(builder => {
-              builder
-                .whereIn('objectPermission.objectId', query => {
-                  query
-                    .distinct('objectPermission.objectId')
-                    .where('objectPermission.permCode', 'READ')
-                    .where('objectPermission.userId', params.userId);
-                })
-                .orWhereIn('object.bucketId', query => {
-                  query
-                    .distinct('bucketPermission.bucketId')
-                    .where('bucketPermission.permCode', 'READ')
-                    .where('bucketPermission.userId', params.userId);
-                });
-            });
-        }
-      })
+      .modify('hasPermission', params.userId, 'READ')
       // format result
       .then(result => {
         // just return object table records
@@ -166,9 +145,9 @@ const service = {
    * @function read
    * Get an object db record
    * @param {string} objId The object uuid to read
-     * @returns {Promise<object>} The result of running the read operation
-     * @throws If there are no records found
-     */
+   * @returns {Promise<object>} The result of running the read operation
+   * @throws If there are no records found
+   */
   read: (objId) => {
     return ObjectModel.query()
       .findById(objId)

--- a/app/src/services/tag.js
+++ b/app/src/services/tag.js
@@ -284,12 +284,11 @@ const service = {
       })
       .modify('filterId', params.versionIds)
       // filter by objects that user(s) has READ permission at object or bucket-level
-      // TODO: consider instead doing `.whereIn('version.objectId', <objects with permission>)`
       .modify((query) => {
         if (params.userId) {
           query
-            .allowGraph('object.[objectPermission, bucketPermission]')
-            .withGraphJoined('object.[objectPermission, bucketPermission]')
+            .allowGraph('object')
+            .withGraphJoined('object')
             .modifyGraph('object', query => { query.modify('hasPermission', params.userId, 'READ'); })
             .whereNotNull('object.id');
         }
@@ -314,9 +313,9 @@ const service = {
         if (params.privacyMask) {
           query
             .select('key')
-            .modify( 'filterKey', { tag: params.tag });
+            .modify('filterKey', { tag: params.tag });
         }
-        else{
+        else {
           query
             .select('key', 'value')
             .modify('filterKeyValue', { tag: params.tag });

--- a/charts/coms/Chart.yaml
+++ b/charts/coms/Chart.yaml
@@ -3,7 +3,7 @@ name: common-object-management-service
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.8
+version: 0.0.9
 kubeVersion: ">= 1.13.0"
 description: A microservice for managing access control to S3 Objects
 # A chart can be either an 'application' or a 'library' chart.

--- a/charts/coms/README.md
+++ b/charts/coms/README.md
@@ -1,6 +1,6 @@
 # common-object-management-service
 
-![Version: 0.0.8](https://img.shields.io/badge/Version-0.0.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.3.0](https://img.shields.io/badge/AppVersion-0.3.0-informational?style=flat-square)
+![Version: 0.0.9](https://img.shields.io/badge/Version-0.0.9-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.3.0](https://img.shields.io/badge/AppVersion-0.3.0-informational?style=flat-square)
 
 A microservice for managing access control to S3 Objects
 


### PR DESCRIPTION
Recently found scoping object search (GET /object) to current user's READ ermission (due to privacyMask config)
was not working in combination with other search params.

Rather than call the object modifier `hasPermission` we  can do something custom for this query.
using joinRelated() and group where clauses to ensure intersection of results

<!-- Provide a general summary of your changes in the Title above -->
# Description

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->