### PR TITLE
Refactor service layer tests to handle multiple model sources

### DIFF
--- a/app/tests/common/dbHelper.js
+++ b/app/tests/common/dbHelper.js
@@ -6,6 +6,7 @@ const retFn = (value) => {
 
 /**
  * @class MockTransaction
+ * @deprecated Only use this as a shape reference
  * Mock Objection Transaction
  */
 class MockTransaction {}
@@ -28,6 +29,7 @@ MockTransaction.mockReset = () => {
 
 /**
  * @class MockModel
+ * @deprecated Only use this as a shape reference
  * Mock Objection Model
  */
 class MockModel {}

--- a/app/tests/common/helper.js
+++ b/app/tests/common/helper.js
@@ -43,6 +43,17 @@ const helper = {
     });
 
     return app;
+  },
+
+  /**
+   * @function resetReturnThis
+   * Updates all jest mocked attributes in `obj` to `mockReturnThis`
+   * @param {object} obj An object with some mocked attributes
+   */
+  resetReturnThis: (obj) => {
+    Object.keys(obj).forEach((f) => {
+      if (jest.isMockFunction(obj[f])) obj[f].mockReturnThis();
+    });
   }
 };
 

--- a/app/tests/unit/services/user.spec.js
+++ b/app/tests/unit/services/user.spec.js
@@ -1,12 +1,40 @@
-const { MockModel, MockTransaction } = require('../../common/dbHelper');
+const { NIL: SYSTEM_USER } = require('uuid');
 
-jest.mock('../../../src/db/models/tables/user', () => MockModel);
-jest.mock('../../../src/db/models/tables/identityProvider', () => MockModel);
+const { resetReturnThis } = require('../../common/helper');
+const IdentityProvider = require('../../../src/db/models/tables/identityProvider');
+const User = require('../../../src/db/models/tables/user');
+
+jest.mock('../../../src/db/models/tables/identityProvider', () => ({
+  commit: jest.fn().mockReturnThis(),
+  rollback: jest.fn().mockReturnThis(),
+  startTransaction: jest.fn().mockReturnThis(),
+
+  findById: jest.fn().mockReturnThis(),
+  insertAndFetch: jest.fn().mockReturnThis(),
+  modify: jest.fn().mockReturnThis(),
+  query: jest.fn().mockReturnThis(),
+  where: jest.fn().mockReturnThis()
+}));
+jest.mock('../../../src/db/models/tables/user', () => ({
+  commit: jest.fn().mockReturnThis(),
+  rollback: jest.fn().mockReturnThis(),
+  startTransaction: jest.fn().mockReturnThis(),
+  throwIfNotFound: jest.fn().mockReturnThis(),
+
+  first: jest.fn().mockReturnThis(),
+  findById: jest.fn().mockReturnThis(),
+  insertAndFetch: jest.fn().mockReturnThis(),
+  modify: jest.fn().mockReturnThis(),
+  patchAndFetchById: jest.fn().mockReturnThis(),
+  query: jest.fn().mockReturnThis(),
+  select: jest.fn().mockReturnThis(),
+  where: jest.fn().mockReturnThis(),
+  whereNotNull: jest.fn().mockReturnThis()
+}));
 
 const service = require('../../../src/services/user');
 
-const userId = '00000000-0000-0000-0000-000000000000';
-
+const userId = SYSTEM_USER;
 const token = {
   sub: userId,
   identity_provider_identity: 'jsmith:idir',
@@ -17,7 +45,6 @@ const token = {
   email: 'jsmith@email.com',
   identity_provider: 'idir'
 };
-
 const user = {
   userId: userId,
   identityId: userId,
@@ -30,59 +57,38 @@ const user = {
 };
 
 beforeEach(() => {
-  MockModel.mockReset();
-  MockTransaction.mockReset();
-});
-
-afterEach(() => {
   jest.clearAllMocks();
+  resetReturnThis(IdentityProvider);
+  resetReturnThis(User);
 });
 
 describe('_tokenToUser', () => {
   // TODO: Add more edge case testing
   it('Transforms JWT payload contents into a User Model object', () => {
+    const expected = { ...user, userId: undefined };
     const newUser = service._tokenToUser(token);
-    expect(newUser).toEqual(user);
+    expect(newUser).toEqual(expected);
   });
 });
 
 
 describe('createIdp', () => {
-  it('Does nothing if no idp provided', async () => {
-    const result = await service.createIdp(undefined);
+  it('Creates an IDP record', async () => {
+    await service.createIdp('foo');
 
-    expect(result).toEqual(undefined);
-    expect(MockModel.startTransaction).toHaveBeenCalledTimes(1);
-    expect(MockModel.query).toHaveBeenCalledTimes(1);
-  });
-
-  it('Inserts idp', async () => {
-    MockModel.mockResolvedValue(undefined);
-    MockModel.mockResolvedValue({
-      idp: 'idir',
-      createdBy: '00000000-0000-0000-0000-000000000000',
-    });
-    let result = await service.createIdp('idir');
-
-    expect(MockModel.query).toHaveBeenCalledTimes(1);
-    expect(MockModel.query).toHaveBeenCalledWith(expect.anything());
-    expect(MockModel.insertAndFetch).toBeCalledWith(
+    expect(IdentityProvider.startTransaction).toHaveBeenCalledTimes(1);
+    expect(IdentityProvider.query).toHaveBeenCalledTimes(1);
+    expect(IdentityProvider.query).toHaveBeenCalledWith(expect.anything());
+    expect(IdentityProvider.insertAndFetch).toHaveBeenCalledTimes(1);
+    expect(IdentityProvider.insertAndFetch).toBeCalledWith(
       expect.objectContaining({
-        idp: expect.any(String),
-        createdBy: expect.anything(),
+        idp: 'foo',
+        createdBy: expect.any(String),
       })
     );
-    expect(MockModel.insertAndFetch).toHaveBeenCalledTimes(1);
-    expect(MockTransaction.commit).toHaveBeenCalledTimes(1);
-    expect(result).toEqual(
-      expect.objectContaining({
-        idp: 'idir',
-        createdBy: expect.anything(),
-      })
-    );
+    expect(IdentityProvider.commit).toHaveBeenCalledTimes(1);
   });
 });
-
 
 describe('createUser', () => {
   const readIdpSpy = jest.spyOn(service, 'readIdp');
@@ -100,41 +106,97 @@ describe('createUser', () => {
 
   it('Creates an idp if no matching idp exists in database', async () => {
     readIdpSpy.mockReturnValue(false);
-    const etrx = await jest.fn().mockResolvedValue(MockTransaction);
-    await service.createUser(user, etrx);
+    await service.createUser(user);
 
-    expect(readIdpSpy).toHaveBeenCalledWith('idir');
     expect(readIdpSpy).toHaveBeenCalledTimes(1);
-    expect(createIdpSpy).toHaveBeenCalledWith('idir', etrx);
+    expect(readIdpSpy).toHaveBeenCalledWith('idir');
     expect(createIdpSpy).toHaveBeenCalledTimes(1);
+    expect(createIdpSpy).toHaveBeenCalledWith('idir', expect.anything());
+
+    expect(User.startTransaction).toHaveBeenCalledTimes(1);
+    expect(User.query).toHaveBeenCalledTimes(1);
+    expect(User.query).toHaveBeenCalledWith(expect.anything());
+    expect(User.insertAndFetch).toHaveBeenCalledTimes(1);
+    expect(User.insertAndFetch).toBeCalledWith(
+      expect.objectContaining({
+        ...user,
+        userId: expect.any(String)
+      })
+    );
+    expect(User.commit).toHaveBeenCalledTimes(1);
   });
 
-  it('Does not create an idp if matching idp already exists in database', async () => {
+  it('Skips creating an idp if matching idp already exists in database', async () => {
     readIdpSpy.mockReturnValue(true);
-    const etrx = await jest.fn().mockResolvedValue(MockTransaction);
-    await service.createUser(user, etrx);
+    await service.createUser(user);
 
+    expect(readIdpSpy).toHaveBeenCalledTimes(1);
+    expect(readIdpSpy).toHaveBeenCalledWith('idir');
     expect(createIdpSpy).toHaveBeenCalledTimes(0);
+
+    expect(User.startTransaction).toHaveBeenCalledTimes(1);
+    expect(User.query).toHaveBeenCalledTimes(1);
+    expect(User.query).toHaveBeenCalledWith(expect.anything());
+    expect(User.insertAndFetch).toHaveBeenCalledTimes(1);
+    expect(User.insertAndFetch).toBeCalledWith(
+      expect.objectContaining({
+        ...user,
+        userId: expect.any(String)
+      })
+    );
+    expect(User.commit).toHaveBeenCalledTimes(1);
   });
 
   it('Does not create an idp if user has none (eg: \'System\' user)', async () => {
     const systemUser = { ...user, idp: undefined };
     await service.createUser(systemUser);
+
     expect(readIdpSpy).toHaveBeenCalledTimes(0);
     expect(createIdpSpy).toHaveBeenCalledTimes(0);
-  });
 
-  it('inserts new user into db', async () => {
-    const etrx = await jest.fn().mockResolvedValue(MockTransaction);
-    await service.createUser(user, etrx);
-
-    expect(MockModel.query).toHaveBeenCalledTimes(1);
-    expect(MockModel.query).toHaveBeenCalledWith(etrx);
-    expect(MockModel.insertAndFetch).toHaveBeenCalledTimes(1);
-    expect(MockModel.insertAndFetch).toHaveReturned();
+    expect(User.startTransaction).toHaveBeenCalledTimes(1);
+    expect(User.query).toHaveBeenCalledTimes(1);
+    expect(User.query).toHaveBeenCalledWith(expect.anything());
+    expect(User.insertAndFetch).toHaveBeenCalledTimes(1);
+    expect(User.insertAndFetch).toBeCalledWith(
+      expect.objectContaining({
+        ...systemUser,
+        userId: expect.any(String)
+      })
+    );
+    expect(User.commit).toHaveBeenCalledTimes(1);
   });
 });
 
+describe('getCurrentUserId', () => {
+  it('Query user by identityId', async () => {
+    User.first.mockResolvedValue({ ...user, userId: '123', identityId: '123-idir' });
+    const result = await service.getCurrentUserId('123-idir');
+
+    expect(User.query).toHaveBeenCalledTimes(1);
+    expect(User.query).toHaveBeenCalledWith();
+    expect(User.select).toHaveBeenCalledTimes(1);
+    expect(User.select).toHaveBeenCalledWith('userId');
+    expect(User.where).toHaveBeenCalledTimes(1);
+    expect(User.where).toHaveBeenCalledWith('identityId', '123-idir');
+    expect(User.first).toHaveBeenCalledTimes(1);
+    expect(User.first).toHaveBeenCalledWith();
+    expect(result).toEqual('123');
+  });
+});
+
+describe('listIdps', () => {
+  it('Query user by identityId', () => {
+    const params = { active: true };
+    service.listIdps(params);
+
+    expect(IdentityProvider.query).toHaveBeenCalledTimes(1);
+    expect(IdentityProvider.query).toHaveBeenCalledWith();
+    expect(IdentityProvider.modify).toHaveBeenCalledTimes(2);
+    expect(IdentityProvider.modify).toHaveBeenNthCalledWith(1, 'filterActive', params.active);
+    expect(IdentityProvider.modify).toHaveBeenNthCalledWith(2, 'orderDefault');
+  });
+});
 
 describe('login', () => {
   const createUserSpy = jest.spyOn(service, 'createUser');
@@ -145,6 +207,8 @@ describe('login', () => {
     tokenToUserSpy.mockReset();
     createUserSpy.mockReset();
     updateUserSpy.mockReset();
+
+    service._tokenToUser = jest.fn().mockReturnValue(user);
   });
 
   afterAll(() => {
@@ -153,46 +217,36 @@ describe('login', () => {
     updateUserSpy.mockRestore();
   });
 
-  service._tokenToUser = jest.fn().mockReturnValue(user);
-
-  it('Checks for existing user in database', async () => {
+  it('Adds a new user record', async () => {
+    User.first.mockResolvedValue(undefined);
     await service.login(token);
 
-    expect(MockModel.query).toHaveBeenCalledTimes(1);
-    expect(MockModel.query).toHaveBeenCalledWith();
-    expect(MockModel.where).toHaveBeenCalledTimes(1);
-    expect(MockModel.where).toHaveBeenCalledWith('identityId', user.identityId);
-  });
+    expect(User.query).toHaveBeenCalledTimes(1);
+    expect(User.query).toHaveBeenCalledWith();
+    expect(User.where).toHaveBeenCalledTimes(1);
+    expect(User.where).toHaveBeenCalledWith('identityId', user.identityId);
+    expect(User.first).toHaveBeenCalledTimes(1);
+    expect(User.first).toHaveBeenCalledWith();
 
-  it('Creates a new user if none found in db with matching userId', async () => {
-    MockModel.mockResolvedValue(undefined);
-    const etrx = await jest.fn().mockResolvedValue(MockTransaction);
-    await service.login(token, etrx);
-
-    // expect(MockModel.startTransaction).toHaveBeenCalledTimes(1);
-    expect(createUserSpy).toHaveBeenCalledWith(user);
     expect(createUserSpy).toHaveBeenCalledTimes(1);
+    expect(createUserSpy).toHaveBeenCalledWith(user);
+    expect(updateUserSpy).toHaveBeenCalledTimes(0);
   });
 
-  it('Update user found in db with matching userId', async () => {
-    MockModel.mockResolvedValue({ ...user, userId: 'a96f2809-d6f4-4cef-a02a-3f72edff06d7' });
+  it('Updates an existing user record', async () => {
+    User.first.mockResolvedValue({ ...user, userId: 'a96f2809-d6f4-4cef-a02a-3f72edff06d7' });
     await service.login(token);
 
-    expect(updateUserSpy).toHaveBeenCalledWith('a96f2809-d6f4-4cef-a02a-3f72edff06d7', user);
-  });
-});
+    expect(User.query).toHaveBeenCalledTimes(1);
+    expect(User.query).toHaveBeenCalledWith();
+    expect(User.where).toHaveBeenCalledTimes(1);
+    expect(User.where).toHaveBeenCalledWith('identityId', user.identityId);
+    expect(User.first).toHaveBeenCalledTimes(1);
+    expect(User.first).toHaveBeenCalledWith();
 
-describe('getCurrentUserId', () => {
-  it('Query user by identityId', async () => {
-    MockModel.mockResolvedValue({ ...user, userId: '123', identityId: '123-idir' });
-
-    const result = await service.getCurrentUserId('123-idir');
-
-    expect(MockModel.query).toHaveBeenCalledTimes(1);
-    expect(MockModel.query).toHaveBeenCalledWith();
-    expect(MockModel.where).toHaveBeenCalledTimes(1);
-    expect(MockModel.where).toHaveBeenCalledWith('identityId', '123-idir');
-    expect(result).toEqual('123');
+    expect(createUserSpy).toHaveBeenCalledTimes(0);
+    expect(updateUserSpy).toHaveBeenCalledTimes(1);
+    expect(updateUserSpy).toHaveBeenCalledWith('a96f2809-d6f4-4cef-a02a-3f72edff06d7', expect.objectContaining(user));
   });
 });
 
@@ -200,41 +254,63 @@ describe('readIdp', () => {
   it('Query identityProvider by code', () => {
     service.readIdp('idir');
 
-    expect(MockModel.query).toHaveBeenCalledTimes(1);
-    expect(MockModel.query).toHaveBeenCalledWith();
-    expect(MockModel.findById).toHaveBeenCalledTimes(1);
-    expect(MockModel.findById).toHaveBeenCalledWith('idir');
+    expect(IdentityProvider.query).toHaveBeenCalledTimes(1);
+    expect(IdentityProvider.query).toHaveBeenCalledWith();
+    expect(IdentityProvider.findById).toHaveBeenCalledTimes(1);
+    expect(IdentityProvider.findById).toHaveBeenCalledWith('idir');
   });
 });
-
 
 describe('readUser', () => {
-  it('Query user table by userId', () => {
-    service.readUser(userId);
+  it('Query user by userId', () => {
+    service.readUser(SYSTEM_USER);
 
-    expect(MockModel.query).toHaveBeenCalledTimes(1);
-    expect(MockModel.query).toHaveBeenCalledWith();
-    expect(MockModel.findById).toHaveBeenCalledTimes(1);
-    expect(MockModel.findById).toHaveBeenCalledWith(userId);
-    expect(MockModel.throwIfNotFound).toHaveBeenCalledTimes(1);
-    expect(MockModel.throwIfNotFound).toHaveBeenCalledWith();
+    expect(User.query).toHaveBeenCalledTimes(1);
+    expect(User.query).toHaveBeenCalledWith();
+    expect(User.findById).toHaveBeenCalledTimes(1);
+    expect(User.findById).toHaveBeenCalledWith(SYSTEM_USER);
+    expect(User.throwIfNotFound).toHaveBeenCalledTimes(1);
+    expect(User.throwIfNotFound).toHaveBeenCalledWith();
   });
 });
 
+describe('searchUsers', () => {
+  it('Query user by identityId', () => {
+    const params = { ...user, active: true, search: 'foo' };
+    service.searchUsers(params);
+
+    expect(User.query).toHaveBeenCalledTimes(1);
+    expect(User.query).toHaveBeenCalledWith();
+    expect(User.modify).toHaveBeenCalledTimes(11);
+    expect(User.modify).toHaveBeenNthCalledWith(1, 'filterUserId', params.userId);
+    expect(User.modify).toHaveBeenNthCalledWith(2, 'filterIdentityId', params.identityId);
+    expect(User.modify).toHaveBeenNthCalledWith(3, 'filterIdp', params.idp);
+    expect(User.modify).toHaveBeenNthCalledWith(4, 'filterUsername', params.username);
+    expect(User.modify).toHaveBeenNthCalledWith(5, 'filterEmail', params.email);
+    expect(User.modify).toHaveBeenNthCalledWith(6, 'filterFirstName', params.firstName);
+    expect(User.modify).toHaveBeenNthCalledWith(7, 'filterFullName', params.fullName);
+    expect(User.modify).toHaveBeenNthCalledWith(8, 'filterLastName', params.lastName);
+    expect(User.modify).toHaveBeenNthCalledWith(9, 'filterActive', params.active);
+    expect(User.modify).toHaveBeenNthCalledWith(10, 'filterSearch', params.search);
+    expect(User.modify).toHaveBeenNthCalledWith(11, 'orderLastFirstAscending');
+    expect(User.whereNotNull).toHaveBeenCalledTimes(1);
+    expect(User.whereNotNull).toHaveBeenCalledWith('identityId');
+  });
+});
 
 describe('updateUser', () => {
-  const oldUser = { ...user, email: 'jsmith@yahoo.com' };
-
   const tokenToUserSpy = jest.spyOn(service, '_tokenToUser');
+  const readUserSpy = jest.spyOn(service, 'readUser');
   const createIdpSpy = jest.spyOn(service, 'createIdp');
   const readIdpSpy = jest.spyOn(service, 'readIdp');
-  const readUserSpy = jest.spyOn(service, 'readUser');
 
   beforeEach(() => {
     tokenToUserSpy.mockReset();
     readIdpSpy.mockReset();
     createIdpSpy.mockReset();
     readUserSpy.mockReset();
+
+    service._tokenToUser = jest.fn().mockReturnValue(user);
   });
 
   afterAll(() => {
@@ -244,50 +320,51 @@ describe('updateUser', () => {
     readUserSpy.mockRestore();
   });
 
-  service._tokenToUser = jest.fn().mockReturnValue(user);
-
   it('Does nothing if user is unchanged', async () => {
     readUserSpy.mockResolvedValue(user);
-    const etrx = await jest.fn().mockResolvedValue(MockTransaction);
-    await service.updateUser(userId, user, etrx);
+    await service.updateUser(userId, user);
 
     expect(readUserSpy).toHaveBeenCalledTimes(1);
     expect(readUserSpy).toHaveBeenCalledWith(userId);
     expect(readIdpSpy).toHaveBeenCalledTimes(0);
     expect(createIdpSpy).toHaveBeenCalledTimes(0);
-    expect(MockModel.query).toHaveBeenCalledTimes(0);
-    expect(MockModel.patchAndFetchById).toHaveBeenCalledTimes(0);
+
+    expect(User.query).toHaveBeenCalledTimes(0);
+    expect(User.patchAndFetchById).toHaveBeenCalledTimes(0);
   });
 
   it('Updates existing user if properties have changed', async () => {
+    const oldUser = { ...user, email: 'jsmith@yahoo.com' };
     readUserSpy.mockResolvedValue(oldUser);
-    const etrx = await jest.fn().mockResolvedValue(MockTransaction);
-    await service.updateUser(userId, user, etrx);
+    await service.updateUser(userId, user);
 
     expect(readUserSpy).toHaveBeenCalledTimes(1);
     expect(readUserSpy).toHaveBeenCalledWith(userId);
-    // TODO: MockModel is not being reset before this test
-    // for next test we should expect it toHaveBeenCalledTimes(1)
-    expect(MockModel.query).toHaveBeenCalledTimes(3);
-    expect(MockModel.query).toHaveBeenCalledWith(etrx);
-    expect(MockModel.patchAndFetchById).toHaveBeenCalledTimes(1);
-    expect(MockModel.patchAndFetchById).toHaveBeenCalledWith(userId, expect.anything(Object));
-    expect(MockModel.patchAndFetchById).toHaveReturned();
+    expect(readIdpSpy).toHaveBeenCalledTimes(0);
+
+    expect(User.query).toHaveBeenCalledTimes(1);
+    expect(User.query).toHaveBeenCalledWith(expect.anything());
+    expect(User.patchAndFetchById).toHaveBeenCalledTimes(1);
+    expect(User.patchAndFetchById).toHaveBeenCalledWith(userId, expect.any(Object));
   });
 
-  // TODO: fix this test.
-  // for some reason, possibly related to transactions, the spied on functions below are not being called.
   it.skip('Creates idp if idp does not exist in db', async () => {
-    let oldUser = { ...user, email: 'jsmith@yahoo.com', idp: 'bceid' };
+    const oldUser = { ...user, email: 'jsmith@yahoo.com', idp: 'newIdp' };
     readUserSpy.mockResolvedValue(oldUser);
-    const etrx = await jest.fn().mockResolvedValue(MockTransaction);
-    await service.updateUser(userId, user, etrx);
+    readIdpSpy.mockResolvedValue(undefined);
+    await service.updateUser(userId, user);
 
     expect(readUserSpy).toHaveBeenCalledTimes(1);
     expect(readUserSpy).toHaveBeenCalledWith(userId);
-    expect(readIdpSpy).toHaveBeenCalledTimes(1);
-    expect(createIdpSpy).toHaveBeenCalledWith(user.idp, etrx);
-    expect(createIdpSpy).toHaveBeenCalledTimes(1);
+    // TODO: For some reason, the spied on functions below are not actually being spy wrapped.
+    // expect(readIdpSpy).toHaveBeenCalledTimes(1);
+    // expect(readIdpSpy).toHaveBeenCalledWith(user.idp, expect.anything());
+    // expect(createIdpSpy).toHaveBeenCalledTimes(1);
+    // expect(createIdpSpy).toHaveBeenCalledWith(user.idp, expect.anything());
+
+    expect(User.query).toHaveBeenCalledTimes(1);
+    expect(User.query).toHaveBeenCalledWith(expect.anything());
+    expect(User.patchAndFetchById).toHaveBeenCalledTimes(1);
+    expect(User.patchAndFetchById).toHaveBeenCalledWith(userId, expect.any(Object));
   });
 });
-

--- a/app/tests/unit/services/version.spec.js
+++ b/app/tests/unit/services/version.spec.js
@@ -1,27 +1,30 @@
-const { MockModel, MockTransaction } = require('../../common/dbHelper');
+const { resetReturnThis } = require('../../common/helper');
+const Version = require('../../../src/db/models/tables/version');
 
-jest.mock('../../../src/db/models/tables/version', () => MockModel);
+jest.mock('../../../src/db/models/tables/version', () => ({
+  commit: jest.fn().mockReturnThis(),
+  rollback: jest.fn().mockReturnThis(),
+  startTransaction: jest.fn().mockReturnThis(),
+
+  orderBy: jest.fn().mockReturnThis(),
+  query: jest.fn().mockReturnThis(),
+  where: jest.fn().mockReturnThis()
+}));
 
 const service = require('../../../src/services/version');
 
 beforeEach(() => {
-  MockModel.mockReset();
-  MockTransaction.mockReset();
-});
-
-afterEach(() => {
   jest.clearAllMocks();
+  resetReturnThis(Version);
 });
 
 describe('list', () => {
-
   it('Query versions by objectId', async () => {
-
     await service.list('abc');
 
-    expect(MockModel.startTransaction).toHaveBeenCalledTimes(1);
-    expect(MockModel.query).toHaveBeenCalledTimes(1);
-    expect(MockModel.where).toHaveBeenCalledWith({ objectId: 'abc' });
-    expect(MockModel.orderBy).toHaveBeenCalledWith('createdAt', 'DESC');
+    expect(Version.startTransaction).toHaveBeenCalledTimes(1);
+    expect(Version.query).toHaveBeenCalledTimes(1);
+    expect(Version.where).toHaveBeenCalledWith({ objectId: 'abc' });
+    expect(Version.orderBy).toHaveBeenCalledWith('createdAt', 'DESC');
   });
 });


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

<!-- Describe your changes in detail -->
Unfortunately due to Jest mock hoisting behavior, we are not able to write a mock Model once and use it multiple places. Our solution now depends on defining the methods we expect to see up front and verbose in the Jest factory function, and depends on us using a new resetReturnThis utility function to approximately mock the chaining behavior that Objection uses.
<!-- Why is this change required? What problem does it solve? -->
These changes set us up so that at least we should be able to assert that our query builder calls have the appropriate calls chained. While they are mostly order independent, this is valuable because the chaining directly influences the kind of SQL query Objection generates under the hood.
<!-- If it fixes an open issue, please link to the issue here. -->
[SHOWCASE-3109](https://apps.nrs.gov.bc.ca/int/jira/browse/SHOWCASE-3109)
[SHOWCASE-3161](https://apps.nrs.gov.bc.ca/int/jira/browse/SHOWCASE-3161)

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->