### PR TITLE
Feature/secret override

### DIFF
--- a/charts/coms/templates/secret.yaml
+++ b/charts/coms/templates/secret.yaml
@@ -48,7 +48,7 @@ data:
   password: {{ .Values.dbSecretOverride.password | default $pPassword | quote }}
   username: {{ .Values.dbSecretOverride.username | default $pUsername | quote }}
 {{- end }}
-{{- if not $oSecret }}
+{{- if and (not $oSecret) (and .Values.objectStorageSecretOverride.password .Values.objectStorageSecretOverride.username) }}
 ---
 apiVersion: v1
 kind: Secret
@@ -64,7 +64,7 @@ data:
   password: {{ .Values.objectStorageSecretOverride.password | default $oPassword | quote }}
   username: {{ .Values.objectStorageSecretOverride.username | default $oUsername | quote }}
 {{- end }}
-{{- if not $kSecret }}
+{{- if and (not $kSecret) (and .Values.keycloakSecretOverride.password .Values.keycloakSecretOverride.username) }}
 ---
 apiVersion: v1
 kind: Secret

--- a/charts/coms/templates/secret.yaml
+++ b/charts/coms/templates/secret.yaml
@@ -2,37 +2,61 @@
 {{- $bUsername := (randAlphaNum 32) | b64enc }}
 {{- $pPassword := (randAlphaNum 32) | b64enc }}
 {{- $pUsername := (randAlphaNum 32) | b64enc }}
+{{- $oPassword := (randAlphaNum 32) | b64enc }}
+{{- $oUsername := (randAlphaNum 32) | b64enc }}
 
 {{- $bSecretName := printf "%s-%s" (include "coms.fullname" .) "basicauth" }}
 {{- $bSecret := (lookup "v1" "Secret" .Release.Namespace $bSecretName ) }}
 {{- $pSecretName := printf "%s-%s" (include "coms.fullname" .) "passphrase" }}
 {{- $pSecret := (lookup "v1" "Secret" .Release.Namespace $pSecretName ) }}
+{{- $oSecretName := printf "%s-%s" (include "coms.fullname" .) "objectstorage" }}
+{{- $oSecret := (lookup "v1" "Secret" .Release.Namespace $oSecretName ) }}
 
 {{- if not $bSecret }}
 ---
 apiVersion: v1
 kind: Secret
 metadata:
+  {{- if not .Values.config.releaseScoped }}
   annotations:
     "helm.sh/resource-policy": keep
+  {{- end }}
   name: {{ $bSecretName }}
   labels: {{ include "coms.labels" . | nindent 4 }}
 type: kubernetes.io/basic-auth
 data:
-  password: {{ .Values.basicAuthSecretOverride.password | default $bPassword | quote }}
-  username: {{ .Values.basicAuthSecretOverride.username | default $bUsername | quote }}
+  password: {{ .Values.basicAuthSecretOverride.password  | default $bPassword | quote }}
+  username: {{ .Values.basicAuthSecretOverride.username  | default $bUsername | quote }}
 {{- end }}
 {{- if not $pSecret }}
 ---
 apiVersion: v1
 kind: Secret
 metadata:
+  {{- if not .Values.config.releaseScoped }}
   annotations:
     "helm.sh/resource-policy": keep
+  {{- end }}
   name: {{ $pSecretName }}
   labels: {{ include "coms.labels" . | nindent 4 }}
 type: kubernetes.io/basic-auth
 data:
-  password: {{ .Values.objectStorageSecretOverride.password | default $pPassword | quote }}
-  username: {{ .Values.objectStorageSecretOverride.username | default $pUsername | quote }}
+  password: {{ .Values.dbSecretOverride.password  | default $pPassword | quote }}
+  username: {{ .Values.dbSecretOverride.username  | default $pUsername | quote }}
+{{- end }}
+{{- if not $oSecret }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  {{- if not .Values.config.releaseScoped }}
+  annotations:
+    "helm.sh/resource-policy": keep
+  {{- end }}
+  name: {{ $oSecretName }}
+  labels: {{ include "coms.labels" . | nindent 4 }}
+type: kubernetes.io/basic-auth
+data:
+  password: {{ .Values.objectStorageSecretOverride.password  | default $oPassword | quote }}
+  username: {{ .Values.objectStorageSecretOverride.username  | default $oUsername | quote }}
 {{- end }}

--- a/charts/coms/templates/secret.yaml
+++ b/charts/coms/templates/secret.yaml
@@ -19,8 +19,8 @@ metadata:
   labels: {{ include "coms.labels" . | nindent 4 }}
 type: kubernetes.io/basic-auth
 data:
-  password: {{ $bPassword }}
-  username: {{ $bUsername }}
+  password: {{ .Values.basicAuthSecretOverride.password | default $bPassword | quote }}
+  username: {{ .Values.basicAuthSecretOverride.username | default $bUsername | quote }}
 {{- end }}
 {{- if not $pSecret }}
 ---
@@ -33,6 +33,6 @@ metadata:
   labels: {{ include "coms.labels" . | nindent 4 }}
 type: kubernetes.io/basic-auth
 data:
-  password: {{ $pPassword }}
-  username: {{ $pUsername }}
+  password: {{ .Values.objectStorageSecretOverride.password | default $pPassword | quote }}
+  username: {{ .Values.objectStorageSecretOverride.username | default $pUsername | quote }}
 {{- end }}

--- a/charts/coms/templates/secret.yaml
+++ b/charts/coms/templates/secret.yaml
@@ -1,16 +1,20 @@
 {{- $bPassword := (randAlphaNum 32) | b64enc }}
 {{- $bUsername := (randAlphaNum 32) | b64enc }}
-{{- $pPassword := (randAlphaNum 32) | b64enc }}
-{{- $pUsername := (randAlphaNum 32) | b64enc }}
+{{- $kPassword := (randAlphaNum 32) | b64enc }}
+{{- $kUsername := (randAlphaNum 32) | b64enc }}
 {{- $oPassword := (randAlphaNum 32) | b64enc }}
 {{- $oUsername := (randAlphaNum 32) | b64enc }}
+{{- $pPassword := (randAlphaNum 32) | b64enc }}
+{{- $pUsername := (randAlphaNum 32) | b64enc }}
 
 {{- $bSecretName := printf "%s-%s" (include "coms.fullname" .) "basicauth" }}
 {{- $bSecret := (lookup "v1" "Secret" .Release.Namespace $bSecretName ) }}
-{{- $pSecretName := printf "%s-%s" (include "coms.fullname" .) "passphrase" }}
-{{- $pSecret := (lookup "v1" "Secret" .Release.Namespace $pSecretName ) }}
+{{- $kSecretName := printf "%s-%s" (include "coms.fullname" .) "keycloak" }}
+{{- $kSecret := (lookup "v1" "Secret" .Release.Namespace $kSecretName ) }}
 {{- $oSecretName := printf "%s-%s" (include "coms.fullname" .) "objectstorage" }}
 {{- $oSecret := (lookup "v1" "Secret" .Release.Namespace $oSecretName ) }}
+{{- $pSecretName := printf "%s-%s" (include "coms.fullname" .) "passphrase" }}
+{{- $pSecret := (lookup "v1" "Secret" .Release.Namespace $pSecretName ) }}
 
 {{- if not $bSecret }}
 ---
@@ -59,4 +63,20 @@ type: kubernetes.io/basic-auth
 data:
   password: {{ .Values.objectStorageSecretOverride.password  | default $oPassword | quote }}
   username: {{ .Values.objectStorageSecretOverride.username  | default $oUsername | quote }}
+{{- end }}
+{{- if not $kSecret }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  {{- if not .Values.config.releaseScoped }}
+  annotations:
+    "helm.sh/resource-policy": keep
+  {{- end }}
+  name: {{ $kSecretName }}
+  labels: {{ include "coms.labels" . | nindent 4 }}
+type: kubernetes.io/basic-auth
+data:
+  password: {{ .Values.keycloakSecretOverride.password  | default $kPassword | quote }}
+  username: {{ .Values.keycloakSecretOverride.username  | default $kUsername | quote }}
 {{- end }}

--- a/charts/coms/templates/secret.yaml
+++ b/charts/coms/templates/secret.yaml
@@ -24,7 +24,7 @@ metadata:
   name: {{ $bSecretName }}
   labels: {{ include "coms.labels" . | nindent 4 }}
 type: kubernetes.io/basic-auth
-data:
+stringData:
   password: {{ .Values.basicAuthSecretOverride.password | default $bPassword | quote }}
   username: {{ .Values.basicAuthSecretOverride.username | default $bUsername | quote }}
 {{- end }}
@@ -40,7 +40,7 @@ metadata:
   name: {{ $pSecretName }}
   labels: {{ include "coms.labels" . | nindent 4 }}
 type: kubernetes.io/basic-auth
-data:
+stringData:
   password: {{ .Values.dbSecretOverride.password | default $pPassword | quote }}
   username: {{ .Values.dbSecretOverride.username | default $pUsername | quote }}
 {{- end }}
@@ -56,7 +56,7 @@ metadata:
   name: {{ $oSecretName }}
   labels: {{ include "coms.labels" . | nindent 4 }}
 type: kubernetes.io/basic-auth
-data:
+stringData:
   password: {{ .Values.objectStorageSecretOverride.password | quote }}
   username: {{ .Values.objectStorageSecretOverride.username | quote }}
 {{- end }}
@@ -72,7 +72,7 @@ metadata:
   name: {{ $kSecretName }}
   labels: {{ include "coms.labels" . | nindent 4 }}
 type: kubernetes.io/basic-auth
-data:
+stringData:
   password: {{ .Values.keycloakSecretOverride.password | quote }}
   username: {{ .Values.keycloakSecretOverride.username | quote }}
 {{- end }}

--- a/charts/coms/templates/secret.yaml
+++ b/charts/coms/templates/secret.yaml
@@ -29,8 +29,8 @@ metadata:
   labels: {{ include "coms.labels" . | nindent 4 }}
 type: kubernetes.io/basic-auth
 data:
-  password: {{ .Values.basicAuthSecretOverride.password  | default $bPassword | quote }}
-  username: {{ .Values.basicAuthSecretOverride.username  | default $bUsername | quote }}
+  password: {{ .Values.basicAuthSecretOverride.password | default $bPassword | quote }}
+  username: {{ .Values.basicAuthSecretOverride.username | default $bUsername | quote }}
 {{- end }}
 {{- if not $pSecret }}
 ---
@@ -45,8 +45,8 @@ metadata:
   labels: {{ include "coms.labels" . | nindent 4 }}
 type: kubernetes.io/basic-auth
 data:
-  password: {{ .Values.dbSecretOverride.password  | default $pPassword | quote }}
-  username: {{ .Values.dbSecretOverride.username  | default $pUsername | quote }}
+  password: {{ .Values.dbSecretOverride.password | default $pPassword | quote }}
+  username: {{ .Values.dbSecretOverride.username | default $pUsername | quote }}
 {{- end }}
 {{- if not $oSecret }}
 ---
@@ -61,8 +61,8 @@ metadata:
   labels: {{ include "coms.labels" . | nindent 4 }}
 type: kubernetes.io/basic-auth
 data:
-  password: {{ .Values.objectStorageSecretOverride.password  | default $oPassword | quote }}
-  username: {{ .Values.objectStorageSecretOverride.username  | default $oUsername | quote }}
+  password: {{ .Values.objectStorageSecretOverride.password | default $oPassword | quote }}
+  username: {{ .Values.objectStorageSecretOverride.username | default $oUsername | quote }}
 {{- end }}
 {{- if not $kSecret }}
 ---
@@ -77,6 +77,6 @@ metadata:
   labels: {{ include "coms.labels" . | nindent 4 }}
 type: kubernetes.io/basic-auth
 data:
-  password: {{ .Values.keycloakSecretOverride.password  | default $kPassword | quote }}
-  username: {{ .Values.keycloakSecretOverride.username  | default $kUsername | quote }}
+  password: {{ .Values.keycloakSecretOverride.password | default $kPassword | quote }}
+  username: {{ .Values.keycloakSecretOverride.username | default $kUsername | quote }}
 {{- end }}

--- a/charts/coms/templates/secret.yaml
+++ b/charts/coms/templates/secret.yaml
@@ -1,9 +1,5 @@
 {{- $bPassword := (randAlphaNum 32) | b64enc }}
 {{- $bUsername := (randAlphaNum 32) | b64enc }}
-{{- $kPassword := (randAlphaNum 32) | b64enc }}
-{{- $kUsername := (randAlphaNum 32) | b64enc }}
-{{- $oPassword := (randAlphaNum 32) | b64enc }}
-{{- $oUsername := (randAlphaNum 32) | b64enc }}
 {{- $pPassword := (randAlphaNum 32) | b64enc }}
 {{- $pUsername := (randAlphaNum 32) | b64enc }}
 
@@ -61,8 +57,8 @@ metadata:
   labels: {{ include "coms.labels" . | nindent 4 }}
 type: kubernetes.io/basic-auth
 data:
-  password: {{ .Values.objectStorageSecretOverride.password | default $oPassword | quote }}
-  username: {{ .Values.objectStorageSecretOverride.username | default $oUsername | quote }}
+  password: {{ .Values.objectStorageSecretOverride.password | quote }}
+  username: {{ .Values.objectStorageSecretOverride.username | quote }}
 {{- end }}
 {{- if and (not $kSecret) (and .Values.keycloakSecretOverride.password .Values.keycloakSecretOverride.username) }}
 ---
@@ -77,6 +73,6 @@ metadata:
   labels: {{ include "coms.labels" . | nindent 4 }}
 type: kubernetes.io/basic-auth
 data:
-  password: {{ .Values.keycloakSecretOverride.password | default $kPassword | quote }}
-  username: {{ .Values.keycloakSecretOverride.username | default $kUsername | quote }}
+  password: {{ .Values.keycloakSecretOverride.password | quote }}
+  username: {{ .Values.keycloakSecretOverride.username | quote }}
 {{- end }}

--- a/charts/coms/values.yaml
+++ b/charts/coms/values.yaml
@@ -148,7 +148,7 @@ config:
     # SERVER_PRIVACY_MASK: "true"
 
 # Modify the following variables if you need to acquire secret values from a custom-named resource
-basicAuthSecretOverride: 
+basicAuthSecretOverride:
   username: ~
   password: ~
 dbSecretOverride:

--- a/charts/coms/values.yaml
+++ b/charts/coms/values.yaml
@@ -148,10 +148,18 @@ config:
     # SERVER_PRIVACY_MASK: "true"
 
 # Modify the following variables if you need to acquire secret values from a custom-named resource
-basicAuthSecretOverride: ~
-dbSecretOverride: ~
-keycloakSecretOverride: ~
-objectStorageSecretOverride: ~
+basicAuthSecretOverride: 
+  username: ~
+  password: ~
+dbSecretOverride:
+  username: ~
+  password: ~
+keycloakSecretOverride:
+  username: ~
+  password: ~
+objectStorageSecretOverride:
+  username: ~
+  password: ~
 
 # Patroni subchart configuration overrides
 patroni:


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description
Refactored Secret objects to use stringData instead of Data as field.  This prevents base64 error when trying to pull data into the secret that may not be base64 (such as usernames).

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes
Refactor w/ encryption side effects (should make Secrets work as intended).

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments
Tested with manual helm install, and NOT piping secrets to | base64.

This wasn't a tested workflow during the original PR (was feeding test data to base64, overlooking the usual flow of just placing stringData into the secret)
  
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->