### PR TITLE
Updated email validator to use a custom regex

### DIFF
--- a/app/src/components/constants.js
+++ b/app/src/components/constants.js
@@ -32,6 +32,12 @@ module.exports = Object.freeze({
     URL: 'url'
   },
 
+  /**
+   * Generic email regex modified to require domain of at least 2 characters
+   * @see {@link https://emailregex.com/}
+   */
+  EMAILREGEX: '^[a-zA-Z0-9.!#$%&’*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\\.[a-zA-Z0-9-]{2,})+$',
+
   /** Maximum Content Length supported by S3 CopyObjectCommand */
   MAXCOPYOBJECTLENGTH: 5 * 1024 * 1024 * 1024,
 

--- a/app/src/validators/common.js
+++ b/app/src/validators/common.js
@@ -1,6 +1,6 @@
 const { Joi: baseJoi } = require('express-validation');
 
-const { Permissions } = require('../components/constants');
+const { EMAILREGEX, Permissions } = require('../components/constants');
 
 /**
  * @constant Joi
@@ -39,7 +39,7 @@ const type = {
   truthy: Joi.boolean()
     .truthy('true', 1, '1', 't', 'yes', 'y', 'false', 0, '0', 'f', 'no', 'n'),
 
-  email: Joi.string().max(255).email(),
+  email: Joi.string().pattern(new RegExp(EMAILREGEX)).max(255),
 
   uuidv4: Joi.string().guid({
     version: 'uuidv4'

--- a/app/tests/unit/validators/common.spec.js
+++ b/app/tests/unit/validators/common.spec.js
@@ -2,7 +2,7 @@ const crypto = require('crypto');
 const jestJoi = require('jest-joi');
 expect.extend(jestJoi.matchers);
 
-const { Permissions } = require('../../../src/components/constants');
+const { EMAILREGEX, Permissions } = require('../../../src/components/constants');
 const { scheme, type } = require('../../../src/validators/common');
 
 describe('type', () => {
@@ -50,7 +50,6 @@ describe('type', () => {
 
   describe('email', () => {
     const model = type.email.describe();
-
     it('is a string', () => {
       expect(model).toBeTruthy();
       expect(model.type).toEqual('string');
@@ -60,14 +59,18 @@ describe('type', () => {
       expect(Array.isArray(model.rules)).toBeTruthy();
       expect(model.rules).toHaveLength(2);
       expect(model.rules).toEqual(expect.arrayContaining([
-        expect.objectContaining(
-          {
-            'args': {
-              'limit': 255
-            },
-            'name': 'max'
+        expect.objectContaining({
+          'args': {
+            'regex': new RegExp(EMAILREGEX).toString()
           },
-          { 'name': 'email' })
+          'name': 'pattern'
+        }),
+        expect.objectContaining({
+          'args': {
+            'limit': 255
+          },
+          'name': 'max'
+        })
       ]));
     });
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

Updated email validator to use a custom regex. Prevents a 422 error when attempting to search an email with more than 2 domains.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [ ] I have checked that unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->