### PR TITLE
Various bugfixes: metadata pruning, public toggle and updatedAt systemuser attribution

### DIFF
--- a/app/src/controllers/object.js
+++ b/app/src/controllers/object.js
@@ -439,7 +439,6 @@ const controller = {
       const bucketId = req.currentObject?.bucketId;
       const objId = addDashesToUuid(req.params.objectId);
       const objPath = await getPath(objId);
-      const userId = await userService.getCurrentUserId(getCurrentIdentity(req.currentUser, SYSTEM_USER));
 
       // Target S3 version
       const targetS3VersionId = await getS3VersionId(req.query.s3VersionId, addDashesToUuid(req.query.versionId), objId);
@@ -476,7 +475,7 @@ const controller = {
         } else if (objectTagging.TagSet && objectTagging.TagSet.length) {
           dissociateTags = toLowerKeys(objectTagging.TagSet);
         }
-        if (dissociateTags.length) await tagService.dissociateTags(version.id, dissociateTags, userId, trx);
+        if (dissociateTags.length) await tagService.dissociateTags(version.id, dissociateTags, trx);
       });
 
       res.status(204).end();
@@ -812,11 +811,11 @@ const controller = {
    */
   async togglePublic(req, res, next) {
     try {
-      const userId = await userService.getCurrentUserId(req.currentUser, SYSTEM_USER);
+      const userId = await userService.getCurrentUserId(getCurrentIdentity(req.currentUser, SYSTEM_USER), SYSTEM_USER);
       const data = {
         id: addDashesToUuid(req.params.objectId),
-        updatedBy: userId
         public: isTruthy(req.query.public) ?? false,
+        userId: userId
       };
 
       const response = await objectService.update(data);

--- a/app/src/controllers/object.js
+++ b/app/src/controllers/object.js
@@ -815,8 +815,8 @@ const controller = {
       const userId = await userService.getCurrentUserId(req.currentUser, SYSTEM_USER);
       const data = {
         id: addDashesToUuid(req.params.objectId),
-        public: isTruthy(req.query.public),
         updatedBy: userId
+        public: isTruthy(req.query.public) ?? false,
       };
 
       const response = await objectService.update(data);

--- a/app/src/services/bucket.js
+++ b/app/src/services/bucket.js
@@ -94,7 +94,7 @@ const service = {
       const response = await Bucket.query(trx).insert(obj).returning('*');
 
       // Add all permission codes for the uploader
-      if (data.userId) {
+      if (data.userId && data.userId !== SYSTEM_USER) {
         const perms = Object.values(Permissions).map((p) => ({
           userId: data.userId,
           permCode: p

--- a/app/src/services/metadata.js
+++ b/app/src/services/metadata.js
@@ -39,9 +39,6 @@ const service = {
               .whereIn('metadataId', dissociateMetadata.map(vm => vm.metadataId))
               .modify('filterVersionId', versionId)
               .delete();
-
-            // delete all orphaned metadata records
-            await service.pruneOrphanedMetadata(trx);
           }
         }
 
@@ -56,6 +53,9 @@ const service = {
               createdBy: currentUserId
             })));
         }
+
+        // delete all orphaned metadata records
+        await service.pruneOrphanedMetadata(trx);
       }
 
       if (!etrx) await trx.commit();

--- a/app/src/services/object.js
+++ b/app/src/services/object.js
@@ -1,3 +1,5 @@
+const { NIL: SYSTEM_USER } = require('uuid');
+
 const objectPermissionService = require('./objectPermission');
 const { Permissions } = require('../components/constants');
 const { ObjectModel } = require('../db/models');
@@ -31,12 +33,12 @@ const service = {
         public: data.public,
         active: data.active,
         bucketId: data.bucketId,
-        createdBy: data.userId
+        createdBy: data.userId ?? SYSTEM_USER
       };
       const response = await ObjectModel.query(trx).insert(obj).returning('*');
 
       // Add all permission codes for the uploader
-      if (data.userId) {
+      if (data.userId && data.userId !== SYSTEM_USER) {
         const perms = Object.values(Permissions).map((p) => ({
           userId: data.userId,
           permCode: p
@@ -176,7 +178,7 @@ const service = {
         path: data.path,
         public: data.public,
         active: data.active,
-        updatedBy: data.userId
+        updatedBy: data.userId ?? SYSTEM_USER
       });
 
       if (!etrx) await trx.commit();

--- a/app/src/services/user.js
+++ b/app/src/services/user.js
@@ -106,6 +106,7 @@ const service = {
    * @returns {string} The current userId if applicable, or `defaultValue`
    */
   getCurrentUserId: async (identityId, defaultValue = undefined) => {
+    // TODO: Consider conditionally skipping when identityId is undefined?
     const user = await User.query()
       .select('userId')
       .where('identityId', identityId)

--- a/app/src/services/version.js
+++ b/app/src/services/version.js
@@ -11,12 +11,12 @@ const service = {
    * @param {string} sourceVersionId S3 VersionId of source version
    * @param {string} newVersionId S3 VersionId of new version
    * @param {string} objectId uuid of the object
-   * @param {string} UserId uuid of the current user
+   * @param {string} userId uuid of the current user
    * @param {object} [etrx=undefined] An optional Objection Transaction object
    * @returns {Promise<object>} The Version created in database
    * @throws The error encountered upon db transaction failure
    */
-  copy: async (sourceVersionId, newVersionId, objectId, userId, etrx = undefined) => {
+  copy: async (sourceVersionId, newVersionId, objectId, userId = SYSTEM_USER, etrx = undefined) => {
     let trx;
     try {
       trx = etrx ? etrx : await Version.startTransaction();
@@ -66,7 +66,7 @@ const service = {
    * @returns {Promise<object>} the Version object inserted into the database
    * @throws The error encountered upon db transaction failure
    */
-  create: async (data = {}, userId, etrx = undefined) => {
+  create: async (data = {}, userId = SYSTEM_USER, etrx = undefined) => {
     let trx;
     try {
       trx = etrx ? etrx : await Version.startTransaction();

--- a/app/tests/unit/services/metadata.spec.js
+++ b/app/tests/unit/services/metadata.spec.js
@@ -77,17 +77,21 @@ beforeEach(() => {
 
 describe('associateMetadata', () => {
   const createMetadataSpy = jest.spyOn(service, 'createMetadata');
+  const pruneOrphanedMetadataSpy = jest.spyOn(service, 'pruneOrphanedMetadata');
 
   beforeEach(() => {
     createMetadataSpy.mockReset();
+    pruneOrphanedMetadataSpy.mockReset();
   });
 
   afterAll(() => {
     createMetadataSpy.mockRestore();
+    pruneOrphanedMetadataSpy.mockRestore();
   });
 
   it('Makes the incoming list of metadata the definitive set associated with versionId', async () => {
     createMetadataSpy.mockResolvedValue({ ...metadata });
+    pruneOrphanedMetadataSpy.mockImplementation(() => { });
 
     await service.associateMetadata(VERSION_ID, metadata);
 
@@ -97,6 +101,10 @@ describe('associateMetadata', () => {
     expect(VersionMetadata.modify).toHaveBeenCalledTimes(1);
     expect(VersionMetadata.modify).toHaveBeenCalledWith('filterVersionId', VERSION_ID);
     expect(metadataTrx.commit).toHaveBeenCalledTimes(1);
+    expect(createMetadataSpy).toHaveBeenCalledTimes(1);
+    expect(createMetadataSpy).toHaveBeenCalledWith(metadata, expect.anything());
+    expect(pruneOrphanedMetadataSpy).toHaveBeenCalledTimes(1);
+    expect(pruneOrphanedMetadataSpy).toHaveBeenCalledWith(expect.anything());
   });
 });
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

<!-- Describe your changes in detail -->
This PR address a various amount of consistency and audit related operations which are needed for consistent synchronization considerations.
- 0a340cf Ensure system user nil uuid is attributed in baseAuth mode
- 57ce849 Bugfix togglePublic to actually set to false
- bb0f259 Ensure metadata pruning happens at the end of the association operation
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->