### PR TITLE
Fix filtering of objects/buckets when searching for permissions

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 # These users will be the default owners for everything in the repo.
 # Unless a later match takes precedence, the following users will be
 # requested for review when someone opens a pull request.
-* @jujaga @kamorel @TimCsaky @dc-bcgov
+* @jujaga @kamorel @TimCsaky

--- a/app/src/controllers/bucketPermission.js
+++ b/app/src/controllers/bucketPermission.js
@@ -34,12 +34,15 @@ const controller = {
       });
       const response = groupByObject('bucketId', 'permissions', bucketPermissions);
 
+      // if also returning buckets with implicit object permissions
       if (isTruthy(req.query.objectPerms)) {
-        // Iteration through bucket and object permissions. If object permission not found, set empty array.
-        const bucketIds = await bucketPermissionService.getBucketIdsWithObject(userIds);
+        const buckets = await bucketPermissionService.listInheritedBucketIds(userIds);
 
-        bucketIds.forEach(bucketId => {
-          if (!response.map(r => r.bucketId).includes(bucketId)) {
+        // merge list of bucket permissions
+        buckets.forEach(bucketId => {
+          if (!response.map(r => r.bucketId).includes(bucketId) &&
+            // limit to to bucketId(s) request query parameter if given
+            (!bucketIds.length || bucketIds.includes(bucketId))) {
             response.push({
               bucketId: bucketId,
               permissions: []

--- a/app/src/controllers/objectPermission.js
+++ b/app/src/controllers/objectPermission.js
@@ -32,10 +32,15 @@ const controller = {
       });
       const response = utils.groupByObject('objectId', 'permissions', result);
 
+      // if also returning inheritied permissions
       if (utils.isTruthy(req.query.bucketPerms)) {
-        const objectIds = await objectPermissionService.getObjectIdsWithBucket(userIds, bucketIds, permCodes);
+        const objectIds = await objectPermissionService.listInheritedObjectIds(userIds, bucketIds, permCodes);
+
+        // merge list of object permissions
         objectIds.forEach(objectId => {
-          if (!response.map(r => r.objectId).includes(objectId)) {
+          if (!response.map(r => r.objectId).includes(objectId) &&
+            // limit to objectId request query parameter if given
+            (!objIds.length || objIds.includes(objectId))) {
             response.push({
               objectId: objectId,
               permissions: []

--- a/app/src/services/bucketPermission.js
+++ b/app/src/services/bucketPermission.js
@@ -109,17 +109,17 @@ const service = {
   },
 
   /**
-   * @function getBucketIdsWithObject
-   * Searches for specific (bucket) object permissions
-   * @param {string|string[]} [params.userId] Optional string or array of uuids representing the user
+   * @function listInheritedBucketIds
+   * Get buckets that contain objects with any permissions for given user(s)
+   * @param {string[]} [params.userId] Optional array of uuids representing the user
    * @returns {Promise<object>} The result of running the find operation
    */
-  getBucketIdsWithObject: async (userId) => {
+  listInheritedBucketIds: async (userIds = []) => {
     return ObjectPermission.query()
       .select('bucketId')
       .distinct('userId')
       .joinRelated('object')
-      .modify('filterUserId', userId)
+      .modify('filterUserId', userIds)
       .whereNotNull('bucketId')
       .then(response => response.map(entry => entry.bucketId));
   },

--- a/app/src/services/objectPermission.js
+++ b/app/src/services/objectPermission.js
@@ -62,19 +62,22 @@ const service = {
   },
 
   /**
-   * @function getObjectIdsWithBucket
-   * Searches for specific (object) bucket permissions
+   * @function listInheritedObjectIds
+   * Get objects that are in bucket(s) with given permission(s) for given user(s)
+   * with given permission(s) for given user(s).
    * @param {string[]} [params.userIds] Optional array of user id(s)
    * @param {string[]} [params.bucketIds] Optional array of bucket id(s)
    * @param {string[]} [params.permCodes] Optional array of PermCode(s)
    * @returns {Promise<object>} The result of running the find operation
   */
-  getObjectIdsWithBucket: async (userIds = [], bucketIds = [], permCodes = []) => {
+  listInheritedObjectIds: async (userIds = [], bucketIds = [], permCodes = []) => {
     return BucketPermission.query()
       .distinct('object.id AS objectId')
       .rightJoin('object', 'bucket_permission.bucketId', '=', 'object.bucketId')
       .modify((query) => {
         if (userIds.length) query.modify('filterUserId', userIds);
+      })
+      .modify((query) => {
         if (bucketIds.length) query.whereIn('bucket_permission.bucketId', bucketIds);
         if (permCodes.length) query.whereIn('bucket_permission.permCode', permCodes);
       })

--- a/app/tests/unit/services/bucketPermission.spec.js
+++ b/app/tests/unit/services/bucketPermission.spec.js
@@ -86,11 +86,11 @@ describe('removePermissions', () => {
   });
 });
 
-describe('getBucketIdsWithObject', () => {
+describe('listInheritedBucketIds', () => {
   it('Searches for specific (bucket) object permissions', async () => {
     ObjectPermission.then.mockImplementation();
 
-    await service.getBucketIdsWithObject();
+    await service.listInheritedBucketIds();
 
     expect(ObjectPermission.query).toHaveBeenCalledTimes(1);
     expect(ObjectPermission.select).toHaveBeenCalledTimes(1);

--- a/app/tests/unit/services/objectPermission.spec.js
+++ b/app/tests/unit/services/objectPermission.spec.js
@@ -67,15 +67,15 @@ describe('addPermissions', () => {
   });
 });
 
-describe('getObjectIdsWithBucket', () => {
+describe('listInheritedObjectIds', () => {
   it('searches for specific (object) bucket permissions', async () => {
     BucketPermission.then.mockImplementation();
 
-    await service.getObjectIdsWithBucket();
+    await service.listInheritedObjectIds();
 
     expect(BucketPermission.distinct).toHaveBeenCalledTimes(1);
     expect(BucketPermission.rightJoin).toHaveBeenCalledTimes(1);
-    expect(BucketPermission.modify).toHaveBeenCalledTimes(1);
+    expect(BucketPermission.modify).toHaveBeenCalledTimes(2);
     expect(BucketPermission.then).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

When searching 'implicit' permissions (passing bucketPerms or objectPerms = true)  we were ignoring filtering of first-class entity.
supports ticket: https://apps.nrs.gov.bc.ca/int/jira/browse/SHOWCASE-3227

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->