### PR TITLE
Standardize delimiter behavior for Bucket attributes

### DIFF
--- a/app/src/components/utils.js
+++ b/app/src/components/utils.js
@@ -398,6 +398,17 @@ const utils = {
   },
 
   /**
+   * @function stripDelimit
+   * Yields a string `s` that will never have a trailing delimiter. Returns an empty string if falsy.
+   * @param {string} s The input string
+   * @returns {string} The string `s` without the trailing delimiter, or an empty string.
+   */
+  stripDelimit(s) {
+    if (s) return s.endsWith(DELIMITER) ? utils.stripDelimit(s.slice(0, -1)) : s;
+    else return '';
+  },
+
+  /**
    * @function toLowerKeys
    * Converts all key names for all objects in an array to lowercase
    * @param {object[]} arr Array of tag objects (eg: [{Key: k1, Value: V1}])

--- a/app/src/controllers/bucket.js
+++ b/app/src/controllers/bucket.js
@@ -77,7 +77,7 @@ const controller = {
         accessKeyId: credentials.accessKeyId,
         bucket: credentials.bucket,
         endpoint: credentials.endpoint,
-        key: credentials.key,
+        key: credentials.key ? credentials.key : '/',
         region: credentials.region || DEFAULTREGION,
         secretAccessKey: credentials.secretAccessKey,
       };

--- a/app/src/controllers/bucket.js
+++ b/app/src/controllers/bucket.js
@@ -7,9 +7,10 @@ const errorToProblem = require('../components/errorToProblem');
 const log = require('../components/log')(module.filename);
 const {
   addDashesToUuid,
+  getCurrentIdentity,
   isTruthy,
   mixedQueryToArray,
-  getCurrentIdentity
+  stripDelimit
 } = require('../components/utils');
 const { redactSecrets } = require('../db/models/utils');
 
@@ -102,7 +103,11 @@ const controller = {
    * @returns {function} Express middleware function
    */
   async createBucket(req, res, next) {
-    const data = { ...req.body };
+    const data = {
+      ...req.body,
+      endpoint: stripDelimit(req.body.endpoint),
+      key: req.body.key ? stripDelimit(req.body.key) : undefined
+    };
     let response = undefined;
 
     try {
@@ -221,7 +226,11 @@ const controller = {
 
       // Check for credential accessibility/validity first
       // Need to cross reference with existing data when partial patch data is provided
-      await controller._validateCredentials({ ...currentBucket, ...req.body });
+      await controller._validateCredentials({
+        ...currentBucket,
+        ...req.body,
+        endpoint: req.body.endpoint ? stripDelimit(req.body.endpoint) : currentBucket.endpoint
+      });
 
       const userId = await userService.getCurrentUserId(getCurrentIdentity(req.currentUser, SYSTEM_USER), SYSTEM_USER);
       const response = await bucketService.update({
@@ -229,8 +238,7 @@ const controller = {
         bucketName: req.body.bucketName,
         accessKeyId: req.body.accessKeyId,
         bucket: req.body.bucket,
-        endpoint: req.body.endpoint,
-        key: req.body.key,
+        endpoint: req.body.endpoint ? stripDelimit(req.body.endpoint) : undefined,
         secretAccessKey: req.body.secretAccessKey,
         region: req.body.region,
         active: isTruthy(req.body.active),

--- a/app/src/docs/v1.api-spec.yaml
+++ b/app/src/docs/v1.api-spec.yaml
@@ -79,14 +79,7 @@ paths:
         content:
           application/json:
             schema:
-              allOf:
-                - $ref: "#/components/schemas/Request-Bucket"
-                - required:
-                    - accessKeyId
-                    - bucket
-                    - bucketName
-                    - endpoint
-                    - secretAccessKey
+              $ref: "#/components/schemas/Request-CreateBucket"
       responses:
         "201":
           description: Returns inserted DB bucket record
@@ -177,7 +170,7 @@ paths:
             schema:
               type: array
               items:
-                $ref: "#/components/schemas/Request-Bucket"
+                $ref: "#/components/schemas/Request-UpdateBucket"
       parameters:
         - $ref: "#/components/parameters/Path-BucketId"
       responses:
@@ -1660,12 +1653,14 @@ components:
               example: ac246e31-c807-496c-bc93-cd8bc2f1b2b4
             endpoint:
               type: string
-              description: the S3 service URI
+              description: A valid RFC 3986 formatted S3 Service URI endpoint
+              maxLength: 255
               example: https://my-objectstore.ca
             key:
               description: The prefix given to objects in the bucket
               type: string
               example: coms/env
+              maxLength: 255
             region:
               type: string
               description: >-
@@ -1987,8 +1982,28 @@ components:
         - DELETE
         - MANAGE
       example: UPDATE
-    Request-Bucket:
-      title: Response Bucket
+    Request-CreateBucket:
+      title: Request Create Bucket
+      type: object
+      required:
+        - accessKeyId
+        - bucket
+        - bucketName
+        - endpoint
+        - secretAccessKey
+      allOf:
+        - $ref: "#/components/schemas/Request-UpdateBucket"
+        - type: object
+          properties:
+            key:
+              description: >-
+                The prefix given to objects in the bucket. Defaults to "/" if
+                undefined.
+              type: string
+              default: /
+              example: coms/env
+    Request-UpdateBucket:
+      title: Request Update Bucket
       type: object
       properties:
         accessKeyId:
@@ -2012,12 +2027,9 @@ components:
           example: Geospatial Maps
         endpoint:
           type: string
-          description: the S3 service URI
+          description: A valid RFC 3986 formatted S3 Service URI endpoint
+          maxLength: 255
           example: https://my-objectstore.ca
-        key:
-          description: The prefix given to objects in the bucket
-          type: string
-          example: coms/env
         region:
           type: string
           description: >-

--- a/app/src/services/bucket.js
+++ b/app/src/services/bucket.js
@@ -202,7 +202,6 @@ const service = {
    * @param {string} [data.accessKeyId] The optional S3 bucket access key id
    * @param {string} [data.bucket] The optional S3 bucket identifier
    * @param {string} [data.endpoint] The optional S3 bucket endpoint
-   * @param {string} [data.key] The optional relative S3 key/subpath managed by this bucket
    * @param {string} [data.secretAccessKey] The optional S3 bucket secret access key
    * @param {string} [data.region] The optional S3 bucket region
    * @param {boolean} [data.active] The optional active flag - defaults to true if undefined
@@ -221,7 +220,6 @@ const service = {
         accessKeyId: data.accessKeyId,
         bucket: data.bucket,
         endpoint: data.endpoint,
-        key: data.key,
         secretAccessKey: data.secretAccessKey,
         region: data.region,
         active: data.active,

--- a/app/src/services/bucket.js
+++ b/app/src/services/bucket.js
@@ -30,7 +30,7 @@ const service = {
       const bucket = await service.readUnique({
         bucket: data.bucket,
         endpoint: data.endpoint,
-        key: data.key
+        key: data.key ? data.key : '/'
       });
 
       if (
@@ -84,7 +84,7 @@ const service = {
         accessKeyId: data.accessKeyId,
         bucket: data.bucket,
         endpoint: data.endpoint,
-        key: data.key ? data.key : '', // TODO: to be refactored after the DB change
+        key: data.key ? data.key : '/',
         secretAccessKey: data.secretAccessKey,
         region: data.region,
         active: data.active,

--- a/app/src/validators/bucket.js
+++ b/app/src/validators/bucket.js
@@ -9,7 +9,7 @@ const schema = {
       accessKeyId: Joi.string().max(255).required(),
       bucket: Joi.string().max(255).required(),
       endpoint: Joi.string().max(255).required(),
-      key: Joi.string().max(255),
+      key: Joi.string().trim().max(255),
       secretAccessKey: Joi.string().max(255).required(),
       region: Joi.string().max(255),
       active: type.truthy
@@ -49,7 +49,6 @@ const schema = {
       accessKeyId: Joi.string().max(255),
       bucket: Joi.string().max(255),
       endpoint: Joi.string().max(255),
-      key: Joi.string().max(255),
       secretAccessKey: Joi.string().max(255),
       region: Joi.string().max(255),
       active: type.truthy

--- a/app/src/validators/bucket.js
+++ b/app/src/validators/bucket.js
@@ -8,7 +8,7 @@ const schema = {
       bucketName: Joi.string().max(255).required(),
       accessKeyId: Joi.string().max(255).required(),
       bucket: Joi.string().max(255).required(),
-      endpoint: Joi.string().max(255).required(),
+      endpoint: Joi.string().uri({ scheme: /https?/ }).max(255).required(),
       key: Joi.string().trim().max(255),
       secretAccessKey: Joi.string().max(255).required(),
       region: Joi.string().max(255),
@@ -48,7 +48,7 @@ const schema = {
       bucketName: Joi.string().max(255),
       accessKeyId: Joi.string().max(255),
       bucket: Joi.string().max(255),
-      endpoint: Joi.string().max(255),
+      endpoint: Joi.string().uri({ scheme: /https?/ }).max(255),
       secretAccessKey: Joi.string().max(255),
       region: Joi.string().max(255),
       active: type.truthy

--- a/app/tests/unit/components/utils.spec.js
+++ b/app/tests/unit/components/utils.spec.js
@@ -621,6 +621,26 @@ describe('streamToBuffer', () => {
   });
 });
 
+describe('stripDelimit', () => {
+  it.each([
+    // Should return empty string if falsy input
+    ['', undefined],
+    ['', null],
+    ['', ''],
+    // Strings without trailing delimiters should remain unchanged
+    ['1234', '1234'],
+    ['foo', 'foo'],
+    ['bar\\', 'bar\\'],
+    // Strings with trailing delimiters should have the delimiter removed
+    ['1234', '1234/'],
+    ['    ', '    /'],
+    ['', '/'],
+    ['', '//'],
+  ])('should return %o given %j', (expected, str) => {
+    expect(utils.stripDelimit(str)).toEqual(expected);
+  });
+});
+
 describe('toLowerKeys', () => {
   it.each([
     [undefined, undefined],

--- a/app/tests/unit/controllers/bucket.spec.js
+++ b/app/tests/unit/controllers/bucket.spec.js
@@ -65,7 +65,7 @@ describe('createBucket', () => {
     await controller.createBucket(req, res, next);
 
     expect(headBucketSpy).toHaveBeenCalledTimes(1);
-    expect(headBucketSpy).toHaveBeenCalledWith(req.body);
+    expect(headBucketSpy).toHaveBeenCalledWith(expect.objectContaining(req.body));
     expect(getCurrentIdentitySpy).toHaveBeenCalledTimes(1);
     expect(getCurrentIdentitySpy).toHaveBeenCalledWith(
       CURRENT_USER,
@@ -129,7 +129,7 @@ describe('createBucket', () => {
     await controller.createBucket(req, res, next);
 
     expect(headBucketSpy).toHaveBeenCalledTimes(1);
-    expect(headBucketSpy).toHaveBeenCalledWith(req.body);
+    expect(headBucketSpy).toHaveBeenCalledWith(expect.objectContaining(req.body));
     expect(getCurrentIdentitySpy).toHaveBeenCalledTimes(0);
     expect(getCurrentUserIdSpy).toHaveBeenCalledTimes(0);
     expect(createSpy).toHaveBeenCalledTimes(0);
@@ -159,7 +159,7 @@ describe('createBucket', () => {
     await controller.createBucket(req, res, next);
 
     expect(headBucketSpy).toHaveBeenCalledTimes(1);
-    expect(headBucketSpy).toHaveBeenCalledWith(req.body);
+    expect(headBucketSpy).toHaveBeenCalledWith(expect.objectContaining(req.body));
     expect(getCurrentIdentitySpy).toHaveBeenCalledTimes(1);
     expect(getCurrentIdentitySpy).toHaveBeenCalledWith(
       CURRENT_USER,

--- a/app/tests/unit/services/bucket.spec.js
+++ b/app/tests/unit/services/bucket.spec.js
@@ -159,7 +159,6 @@ describe('update', () => {
       accessKeyId: data.accessKeyId,
       bucket: data.bucket,
       endpoint: data.endpoint,
-      key: data.key,
       secretAccessKey: data.secretAccessKey,
       region: data.region,
       active: data.active,

--- a/app/tests/unit/validators/bucket.spec.js
+++ b/app/tests/unit/validators/bucket.spec.js
@@ -9,6 +9,83 @@ describe('createBucket', () => {
   describe('body', () => {
     const body = schema.createBucket.body.describe();
 
+    describe('endpoint', () => {
+      const endpoint = body.keys.endpoint;
+
+      it('is a string', () => {
+        expect(endpoint).toBeTruthy();
+        expect(endpoint.type).toEqual('string');
+      });
+
+      it('is a valid uri', () => {
+        expect(Array.isArray(endpoint.rules)).toBeTruthy();
+        expect(endpoint.rules).toHaveLength(2);
+        expect(endpoint.rules).toEqual(expect.arrayContaining([
+          expect.objectContaining({
+            args: {
+              options: { scheme: /https?/ }
+            },
+            name: 'uri'
+          }),
+        ]));
+      });
+
+      it('has a max length of 255', () => {
+        expect(Array.isArray(endpoint.rules)).toBeTruthy();
+        expect(endpoint.rules).toHaveLength(2);
+        expect(endpoint.rules).toEqual(expect.arrayContaining([
+          expect.objectContaining({
+            args: {
+              limit: 255
+            },
+            name: 'max'
+          }),
+        ]));
+      });
+
+      it('is required', () => {
+        expect(endpoint.flags).toBeTruthy();
+        expect(endpoint.flags).toEqual(expect.objectContaining({
+          presence: 'required'
+        }));
+      });
+    });
+
+    describe('key', () => {
+      const key = body.keys.key;
+
+      it('is a string', () => {
+        expect(key).toBeTruthy();
+        expect(key.type).toEqual('string');
+      });
+
+      it('trims whitespace', () => {
+        expect(Array.isArray(key.rules)).toBeTruthy();
+        expect(key.rules).toHaveLength(2);
+        expect(key.rules).toEqual(expect.arrayContaining([
+          expect.objectContaining({
+            args: {
+              enabled: true
+            },
+            name: 'trim'
+          }),
+        ]));
+      });
+
+      it('has a max length of 255', () => {
+        expect(Array.isArray(key.rules)).toBeTruthy();
+        expect(key.rules).toHaveLength(2);
+        expect(key.rules).toEqual(expect.arrayContaining([
+          expect.objectContaining({
+            args: {
+              limit: 255
+            },
+            name: 'max'
+          }),
+        ]));
+      });
+    });
+
     it('should match the schema', () => {
       const value = {
         body: {
@@ -141,6 +218,41 @@ describe('updateBucket', () => {
 
   describe('body', () => {
     const body = schema.updateBucket.body.describe();
+
+    describe('endpoint', () => {
+      const endpoint = body.keys.endpoint;
+
+      it('is a string', () => {
+        expect(endpoint).toBeTruthy();
+        expect(endpoint.type).toEqual('string');
+      });
+
+      it('is a valid uri', () => {
+        expect(Array.isArray(endpoint.rules)).toBeTruthy();
+        expect(endpoint.rules).toHaveLength(2);
+        expect(endpoint.rules).toEqual(expect.arrayContaining([
+          expect.objectContaining({
+            args: {
+              options: { scheme: /https?/ }
+            },
+            name: 'uri'
+          }),
+        ]));
+      });
+
+      it('has a max length of 255', () => {
+        expect(Array.isArray(endpoint.rules)).toBeTruthy();
+        expect(endpoint.rules).toHaveLength(2);
+        expect(endpoint.rules).toEqual(expect.arrayContaining([
+          expect.objectContaining({
+            args: {
+              limit: 255
+            },
+            name: 'max'
+          }),
+        ]));
+      });
+    });
 
     it('to be an object ', () => {
       expect(body).toBeTruthy();


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

<!-- Describe your changes in detail -->
This PR focuses on standardizing the behavior for bucket attributes so that we can appropriately detect for unique constraint violations in the database for existing buckets. Expected behavior going forwards:
- Endpoint now complies with RFC 3986 and must be a valid http or https URI Domain
- Key is now only insertable; updating the bucket key is no longer permitted.
  - The key shall never be prefixed by a slash.
  - If Key is unspecified on createBucket call, it will now default to "/", or root.
<!-- Why is this change required? What problem does it solve? -->
These changes are required because you would be able to create duplicate bucket records representing the same logical bucket space in the event one of the endpoints terminated with a slash, and the other did not. They are functionally equivalent, but the discrepancy is treated as different entities in the database.

PR changes

- df2b336 Update OpenAPI spec to reflect bucket key changes
- d81e123 Ensure endpoint values are RFC 3986 compliant and do not have trailing '/'
- 5ad992c Disallow updateBucket from modifying the key
- 0e62fca Ensure that bucket keys default to root '/'
- 8b00096 Add stripDelimit utils function

<!-- If it fixes an open issue, please link to the issue here. -->
[SHOWCASE-3254](https://apps.nrs.gov.bc.ca/int/jira/browse/SHOWCASE-3254)

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
Documentation (non-breaking change with enhancements to documentation)
Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->