### PR TITLE
Ensure bucket keys have standardized slash prefix behavior

### DIFF
--- a/app/src/controllers/bucket.js
+++ b/app/src/controllers/bucket.js
@@ -9,6 +9,7 @@ const {
   addDashesToUuid,
   getCurrentIdentity,
   isTruthy,
+  joinPath,
   mixedQueryToArray,
   stripDelimit
 } = require('../components/utils');
@@ -106,7 +107,7 @@ const controller = {
     const data = {
       ...req.body,
       endpoint: stripDelimit(req.body.endpoint),
-      key: req.body.key ? stripDelimit(req.body.key) : undefined
+      key: req.body.key ? joinPath(stripDelimit(req.body.key)) : undefined
     };
     let response = undefined;
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

<!-- Describe your changes in detail -->
In general, COMS handles key paths as relative directories. Since object paths use relative syntax (without a leading slash), we standardize the key to also follow that precedent. In all cases, folder directories such as 'foo' and '/foo' need resolve to the same effective directory so that in the event both are registered in, we do not have duplicate buckets effectively representing the same bucket location.
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

 Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
This will requires a manual DB operation where we remove all leading slashes from the `key` column.