### PR TITLE
Bugfix getKeyValue to gracefully handle undefined inputs

### DIFF
--- a/app/src/components/utils.js
+++ b/app/src/components/utils.js
@@ -178,6 +178,16 @@ const utils = {
   },
 
   /**
+   * @function getKeyValue
+   * Transforms arbitrary {<key>:<value>} objects to {key: <key>, value: <value>}
+   * @param {object} input Arbitrary object containing key value attributes
+   * @returns {object[]} Array of objects in the form of `{key: <key>, value: <value>}`
+   */
+  getKeyValue(input) {
+    return Object.entries({ ...input }).map(([k, v]) => ({ key: k, value: v }));
+  },
+
+  /**
    * @function getMetadata
    * Derives metadata from a request header object
    * @param {object} obj The request headers to get key/value pairs from
@@ -189,6 +199,18 @@ const utils = {
       .map((key) => ([key.toLowerCase().substring(11), obj[key]]))
     );
     return Object.keys(metadata).length ? metadata : undefined;
+  },
+
+  /**
+   * @function getObjectsByKeyValue
+   * Get tag/metadata objects in array that have given key and value
+   * @param {object[]} array an array of objects (eg: [{ key: 'a', value: '1'}, { key: 'b', value: '1'}]
+   * @param {string} key the string to match in the objects's `key` property
+   * @param {string} value the string to match in the objects's `value` property
+   * @returns {object} the matching object, or undefined
+   */
+  getObjectsByKeyValue(array, key, value) {
+    return array.find(obj => (obj.key === key && obj.value === value));
   },
 
   /**
@@ -226,7 +248,7 @@ const utils = {
    * @param {string} objectId The related COMS object id
    * @returns {Promise<string | undefined>} s3 Version id as string type or undefined
    */
-  async getS3VersionId(s3VersionId, versionId, objectId){
+  async getS3VersionId(s3VersionId, versionId, objectId) {
     let result = undefined;
     if (s3VersionId) {
       result = s3VersionId.toString();
@@ -299,29 +321,6 @@ const utils = {
       return parts.join(DELIMITER);
     }
     else return '';
-  },
-
-  /**
-   * @function getKeyValue
-   * Transforms array of {<key>:<value>} objects to {key: <key>, value: <value>}
-   * @param {any}
-   * @param {object[]} input Array of key value tuples like `<key>:<value>`
-   * @returns {object[]} Array of objects like `{key: <key>, value: <value>}`
-   */
-  getKeyValue(input) {
-    return Object.entries(input).map(([k, v]) => ({ key: k, value: v }));
-  },
-
-  /**
-   * @function getObjectsByKeyValue
-   * Get tag/metadata objects in array that have given key and value
-   * @param {object[]} array an array of objects (eg: [{ key: 'a', value: '1'}, { key: 'b', value: '1'}]
-   * @param {string} key the string to match in the objects's `key` property
-   * @param {string} value the string to match in the objects's `value` property
-   * @returns {object} the matching object, or undefined
-   */
-  getObjectsByKeyValue(array, key, value) {
-    return array.find(obj => (obj.key === key && obj.value === value));
   },
 
   /**

--- a/app/tests/unit/components/utils.spec.js
+++ b/app/tests/unit/components/utils.spec.js
@@ -32,25 +32,7 @@ describe('addDashesToUuid', () => {
   });
 });
 
-describe('getMetadata', () => {
-  const headers = {
-    'Content-Length': 1234,
-    'x-amz-meta-foo': 'bar',
-    'x-amz-meta-baz': 'quz',
-    'X-Amz-Meta-Bam': 'blam',
-    'x-AmZ-mEtA-rUn': 'ran',
-  };
-
-  it('should return new object containing metadata headers without x-amz-meta- prefix', () => {
-    expect(utils.getMetadata(headers)).toEqual({
-      foo: 'bar',
-      baz: 'quz',
-      bam: 'blam',
-      run: 'ran'
-    });
-  });
-});
-
+// TODO: Deprecated, to remove this
 describe('getPath', () => {
   const delimitSpy = jest.spyOn(utils, 'delimit');
   const joinPath = jest.spyOn(utils, 'joinPath');
@@ -449,18 +431,33 @@ describe('getCurrentTokenClaim', () => {
   });
 });
 
-describe('getKeyValue', () => {
-  const inputArr = { k1: 'v1', k2: 'v2' };
-  const outputArr = [{ key: 'k1', value: 'v1' }, { key: 'k2', value: 'v2' }];
+describe('getGitRevision', () => {
+  expect(typeof utils.getGitRevision()).toBe('string');
+});
 
-  it('should convert array as expected', () => {
-    expect(utils.getKeyValue(inputArr)).toEqual(outputArr);
-    expect(utils.getKeyValue({})).toEqual([]);
+describe('getKeyValue', () => {
+  it.each([
+    [[], null],
+    [[], undefined],
+    [[], []],
+    [[], {}],
+    [[{ key: 'foo', value: 'bar' }], { foo: 'bar' }],
+    [[{ key: 'k1', value: 'v1' }, { key: 'k2', value: 'v2' }], { k1: 'v1', k2: 'v2' }],
+  ])('should yield %j when given %j', (expected, input) => {
+    expect(utils.getKeyValue(input)).toEqual(expected);
   });
 });
 
-describe('getGitRevision', () => {
-  expect(typeof utils.getGitRevision()).toBe('string');
+describe('getMetadata', () => {
+  it.each([
+    [undefined, {}],
+    [undefined, { 'Content-Length': 1234 }],
+    [{ foo: 'bar' }, { 'Content-Length': 1234, 'x-amz-meta-foo': 'bar' }],
+    [{ foo: 'bar', baz: 'quz' }, { 'Content-Length': 1234, 'x-amz-meta-foo': 'bar', 'x-amz-meta-baz': 'quz' }],
+    [{ bam: 'blam', run: 'ran' }, { 'Content-Length': 1234, 'X-Amz-Meta-Bam': 'blam', 'x-AmZ-mEtA-rUn': 'ran' }],
+  ])('should yield %j when given %j', (expected, input) => {
+    expect(utils.getMetadata(input)).toEqual(expected);
+  });
 });
 
 describe('getObjectsByKeyValue', () => {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

<!-- Describe your changes in detail -->
This was caused by a recent change in the getMetadata function signature where it now emits an undefined in the event the result is an empty set. Extra unit test cases have been added in order to reinforce the newly extended behavior fixes.
<!-- Why is this change required? What problem does it solve? -->
HTTP 502 error when performing a replaceMetadata operation with an empty set of metadata.
<!-- If it fixes an open issue, please link to the issue here. -->
[SHOWCASE-3267](https://apps.nrs.gov.bc.ca/int/jira/browse/SHOWCASE-3267)

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->