### PR TITLE
Implement ability to list all S3 objects at a specific path

### DIFF
--- a/app/src/components/utils.js
+++ b/app/src/components/utils.js
@@ -291,12 +291,28 @@ const utils = {
   },
 
   /**
+   * @function isAtPath
+   * Predicate function determining if the `path` is a member of the `prefix` path
+   * @param {string} prefix The base "folder"
+   * @param {string} path The "file" to check
+   * @returns {boolean} True if path is member of prefix. False in all other cases.
+   */
+  isAtPath(prefix, path) {
+    if (typeof prefix !== 'string' || typeof path !== 'string') return false;
+
+    const pathParts = path.split(DELIMITER).filter(part => part);
+    const prefixParts = prefix.split(DELIMITER).filter(part => part);
+    return prefixParts.every((part, i) => pathParts[i] === part)
+      && pathParts.filter(part => !prefixParts.includes(part)).length === 1;
+  },
+
+  /**
    * @function isTruthy
    * Returns true if the element name in the object contains a truthy value
    * @param {object} value The object to evaluate
    * @returns {boolean} True if truthy, false if not, and undefined if undefined
    */
-  isTruthy: (value) => {
+  isTruthy(value) {
     if (value === undefined) return value;
 
     const isStr = typeof value === 'string' || value instanceof String;

--- a/app/tests/unit/components/utils.spec.js
+++ b/app/tests/unit/components/utils.spec.js
@@ -486,6 +486,30 @@ describe('groupByObject', () => {
   });
 });
 
+describe('isAtPath', () => {
+  it.each([
+    [false, undefined, undefined],
+    [false, null, null],
+    [false, '', ''],
+    [true, '/', 'file'],
+    [false, '/', 'file/bleep'],
+    [true, 'foo', 'foo/bar'],
+    [true, 'foo', '/foo/bar'],
+    [true, '/foo', 'foo/bar'],
+    [true, '/foo', '/foo/bar'],
+    [true, 'a/b', 'a/b/foo.jpg'],
+    [false, 'a/b', 'a/b/z/deep.jpg'],
+    [false, 'a/b', 'a/b/y/z/deep.jpg'],
+    [false, 'a/b/c', 'a/bar.png'],
+    [false, 'c/b/a', 'a/b/c/bar.png'],
+    [false, 'c/a/b', 'a/b/c/bar.png'],
+    [false, 'a/b/c', 'a/c/b/bar.png'],
+    [true, 'a/b/c', 'a/b/c/bar.png'],
+  ])('should return %j given prefix %j and path %j', (expected, prefix, path) => {
+    expect(utils.isAtPath(prefix, path)).toEqual(expected);
+  });
+});
+
 describe('isTruthy', () => {
   it('should return undefined given undefined', () => {
     expect(utils.isTruthy(undefined)).toBeUndefined();


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

<!-- Describe your changes in detail -->
This PR implements the `isAtPath` utility function and the `listAllObjects` utility service wrapper to allow us to reliably get a list of existing S3 objects in an arbitrary bucket. This is necessary in order to handle pagination as well as object path scoping.
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
[SHOWCASE-3256](https://apps.nrs.gov.bc.ca/int/jira/browse/SHOWCASE-3256)

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->