### PR TITLE
Ensure object and bucket searchPermissions endpoints requireSomeAuth

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 # These users will be the default owners for everything in the repo.
 # Unless a later match takes precedence, the following users will be
 # requested for review when someone opens a pull request.
-* @jujaga @kamorel @TimCsaky
+* @jujaga @norrisng-bc @TimCsaky

--- a/app/src/routes/v1/metadata.js
+++ b/app/src/routes/v1/metadata.js
@@ -6,11 +6,11 @@ const { requireDb, requireSomeAuth } = require('../../middleware/featureToggle')
 const { checkAppMode } = require('../../middleware/authorization');
 
 router.use(checkAppMode);
-router.use(requireSomeAuth);
 router.use(requireDb);
+router.use(requireSomeAuth);
 
 /** Search for metadata */
-router.get('/', metadataValidator.searchMetadata, requireDb, (req, res, next) => {
+router.get('/', metadataValidator.searchMetadata, (req, res, next) => {
   metadataController.searchMetadata(req, res, next);
 });
 

--- a/app/src/routes/v1/permission/bucketPermission.js
+++ b/app/src/routes/v1/permission/bucketPermission.js
@@ -8,6 +8,7 @@ const { requireDb, requireSomeAuth } = require('../../../middleware/featureToggl
 
 router.use(checkAppMode);
 router.use(requireDb);
+router.use(requireSomeAuth);
 
 /** Search for bucket permissions */
 router.get('/', bucketPermissionValidator.searchPermissions, (req, res, next) => {
@@ -15,17 +16,17 @@ router.get('/', bucketPermissionValidator.searchPermissions, (req, res, next) =>
 });
 
 /** Returns the bucket permissions */
-router.get('/:bucketId', bucketPermissionValidator.listPermissions, requireSomeAuth, currentObject, hasPermission(Permissions.READ),  (req, res, next) => {
+router.get('/:bucketId', bucketPermissionValidator.listPermissions, currentObject, hasPermission(Permissions.READ),  (req, res, next) => {
   bucketPermissionController.listPermissions(req, res, next);
 });
 
 /** Grants bucket permissions to users */
-router.put('/:bucketId', bucketPermissionValidator.addPermissions, requireSomeAuth, currentObject, hasPermission(Permissions.MANAGE), (req, res, next) => {
+router.put('/:bucketId', bucketPermissionValidator.addPermissions, currentObject, hasPermission(Permissions.MANAGE), (req, res, next) => {
   bucketPermissionController.addPermissions(req, res, next);
 });
 
 /** Deletes bucket permissions for a user */
-router.delete('/:bucketId', bucketPermissionValidator.removePermissions, requireSomeAuth, currentObject, hasPermission(Permissions.MANAGE), (req, res, next) => {
+router.delete('/:bucketId', bucketPermissionValidator.removePermissions, currentObject, hasPermission(Permissions.MANAGE), (req, res, next) => {
   bucketPermissionController.removePermissions(req, res, next);
 });
 

--- a/app/src/routes/v1/permission/objectPermission.js
+++ b/app/src/routes/v1/permission/objectPermission.js
@@ -8,6 +8,7 @@ const { requireDb, requireSomeAuth } = require('../../../middleware/featureToggl
 
 router.use(checkAppMode);
 router.use(requireDb);
+router.use(requireSomeAuth);
 
 /** Search for object permissions */
 router.get('/', objectPermissionValidator.searchPermissions, (req, res, next) => {
@@ -15,17 +16,17 @@ router.get('/', objectPermissionValidator.searchPermissions, (req, res, next) =>
 });
 
 /** Returns the object permissions */
-router.get('/:objectId', objectPermissionValidator.listPermissions, requireSomeAuth, currentObject, hasPermission(Permissions.MANAGE), (req, res, next) => {
+router.get('/:objectId', objectPermissionValidator.listPermissions, currentObject, hasPermission(Permissions.MANAGE), (req, res, next) => {
   objectPermissionController.listPermissions(req, res, next);
 });
 
 /** Grants object permissions to users */
-router.put('/:objectId', objectPermissionValidator.addPermissions, requireSomeAuth, currentObject, hasPermission(Permissions.MANAGE), (req, res, next) => {
+router.put('/:objectId', objectPermissionValidator.addPermissions, currentObject, hasPermission(Permissions.MANAGE), (req, res, next) => {
   objectPermissionController.addPermissions(req, res, next);
 });
 
 /** Deletes object permissions for a user */
-router.delete('/:objectId', objectPermissionValidator.removePermissions, requireSomeAuth, currentObject, hasPermission(Permissions.MANAGE), (req, res, next) => {
+router.delete('/:objectId', objectPermissionValidator.removePermissions, currentObject, hasPermission(Permissions.MANAGE), (req, res, next) => {
   objectPermissionController.removePermissions(req, res, next);
 });
 

--- a/app/src/routes/v1/tag.js
+++ b/app/src/routes/v1/tag.js
@@ -6,11 +6,11 @@ const { requireDb, requireSomeAuth } = require('../../middleware/featureToggle')
 const { checkAppMode } = require('../../middleware/authorization');
 
 router.use(checkAppMode);
-router.use(requireSomeAuth);
 router.use(requireDb);
+router.use(requireSomeAuth);
 
 /** Search for tags */
-router.get('/', tagValidator.searchTags, requireSomeAuth, requireDb, (req, res, next) => {
+router.get('/', tagValidator.searchTags, (req, res, next) => {
   tagController.searchTags(req, res, next);
 });
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

<!-- Describe your changes in detail -->
The searchPermissions endpoints were not protected and was publicly accessible. This commit ensures that there must be an authentication header present before being permitted to execute. This also updates the codeowners file.
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->