### PR TITLE
Add bucketId filter to list ObjectTags/Metadata

### DIFF
--- a/app/src/controllers/object.js
+++ b/app/src/controllers/object.js
@@ -570,9 +570,11 @@ const controller = {
    */
   async fetchMetadata(req, res, next) {
     try {
+      const bucketIds = mixedQueryToArray(req.query.bucketId);
       const objIds = mixedQueryToArray(req.query.objectId);
       const metadata = getMetadata(req.headers);
       const params = {
+        bucketIds: bucketIds ? bucketIds.map(id => addDashesToUuid(id)) : bucketIds,
         objId: objIds ? objIds.map(id => addDashesToUuid(id)) : objIds,
         metadata: metadata && Object.keys(metadata).length ? metadata : undefined
       };
@@ -597,9 +599,11 @@ const controller = {
    */
   async fetchTags(req, res, next) {
     try {
+      const bucketIds = mixedQueryToArray(req.query.bucketId);
       const objIds = mixedQueryToArray(req.query.objectId);
       const tagset = req.query.tagset;
       const params = {
+        bucketIds: bucketIds ? bucketIds.map(id => addDashesToUuid(id)) : bucketIds,
         objectIds: objIds ? objIds.map(id => addDashesToUuid(id)) : objIds,
         tagset: tagset && Object.keys(tagset).length ? tagset : undefined,
       };

--- a/app/src/docs/v1.api-spec.yaml
+++ b/app/src/docs/v1.api-spec.yaml
@@ -736,8 +736,8 @@ paths:
         - Metadata
       parameters:
         - $ref: "#/components/parameters/Header-Metadata"
-        - $ref: "#/components/parameters/Query-ObjectId"
         - $ref: "#/components/parameters/Query-BucketId"
+        - $ref: "#/components/parameters/Query-ObjectId"
       responses:
         "200":
           description: Returns an array objects with matching metadata key/value pairs.
@@ -774,9 +774,9 @@ paths:
       tags:
         - Tagging
       parameters:
-        - $ref: "#/components/parameters/Query-TagSet"
-        - $ref: "#/components/parameters/Query-ObjectId"
         - $ref: "#/components/parameters/Query-BucketId"
+        - $ref: "#/components/parameters/Query-ObjectId"
+        - $ref: "#/components/parameters/Query-TagSet"
       responses:
         "200":
           description: Returns an array objects with matching key/value tag pairs.

--- a/app/src/docs/v1.api-spec.yaml
+++ b/app/src/docs/v1.api-spec.yaml
@@ -737,6 +737,7 @@ paths:
       parameters:
         - $ref: "#/components/parameters/Header-Metadata"
         - $ref: "#/components/parameters/Query-ObjectId"
+        - $ref: "#/components/parameters/Query-BucketId"
       responses:
         "200":
           description: Returns an array objects with matching metadata key/value pairs.
@@ -775,6 +776,7 @@ paths:
       parameters:
         - $ref: "#/components/parameters/Query-TagSet"
         - $ref: "#/components/parameters/Query-ObjectId"
+        - $ref: "#/components/parameters/Query-BucketId"
       responses:
         "200":
           description: Returns an array objects with matching key/value tag pairs.

--- a/app/src/services/metadata.js
+++ b/app/src/services/metadata.js
@@ -119,6 +119,7 @@ const service = {
   /**
    * @function fetchMetadataForObject
    * Fetch metadata for specific objects, optionally scoped to a user's object/bucket READ permission
+  * @param {string[]} [params.bucketIds] An array of uuids representing buckets
    * @param {string[]} params.objId An array of uuids representing the object
    * @param {object} [params.metadata] Optional object of metadata key/value pairs
   * @param {string} [params.userId] Optional uuid representing a user
@@ -126,7 +127,7 @@ const service = {
    */
   fetchMetadataForObject: (params) => {
     return ObjectModel.query()
-      .select('object.id AS objectId')
+      .select('object.id AS objectId', 'object.bucketId as bucketId')
       .allowGraph('version.metadata')
       .withGraphJoined('version.metadata')
       // get latest version that isn't a delete marker by default
@@ -148,6 +149,8 @@ const service = {
       })
       // match on objId parameter
       .modify('filterIds', params.objId)
+      // match on bucketIds parameter
+      .modify('filterBucketIds', params.bucketIds)
       // scope to objects that user(s) has READ permission at object or bucket-level
       .modify('hasPermission', params.userId, 'READ')
       // re-structure result like: [{ objectId: abc, metadata: [{ key: a, value: b }] }]

--- a/app/src/services/tag.js
+++ b/app/src/services/tag.js
@@ -222,6 +222,7 @@ const service = {
   /**
   * @function fetchTagsForObject
   * Fetch matching tags on latest version of provided objects, optionally scoped to a user's object/bucket READ permission
+  * @param {string[]} [params.bucketIds] An array of uuids representing buckets
   * @param {string[]} [params.objectIds] An array of uuids representing objects
   * @param {object} [params.tagset] Optional object of tags key/value pairs
   * @param {string} [params.userId] Optional uuid representing a user
@@ -229,7 +230,7 @@ const service = {
   */
   fetchTagsForObject: (params) => {
     return ObjectModel.query()
-      .select('object.id AS objectId')
+      .select('object.id AS objectId', 'object.bucketId as bucketId')
       .allowGraph('version.tag')
       .withGraphJoined('version.tag')
       // get latest version that isn't a delete marker by default
@@ -251,6 +252,8 @@ const service = {
       })
       // match on objectIds parameter
       .modify('filterIds', params.objectIds)
+      // match on bucketIds parameter
+      .modify('filterBucketIds', params.bucketIds)
       // scope to objects that user(s) has READ permission at object or bucket-level
       .modify('hasPermission', params.userId, 'READ')
       // re-structure result like: [{ objectId: abc, tagset: [{ key: a, value: b }] }]

--- a/app/src/validators/object.js
+++ b/app/src/validators/object.js
@@ -103,6 +103,7 @@ const schema = {
   fetchMetadata: {
     headers: type.metadata(),
     query: Joi.object({
+      bucketId: scheme.guid,
       objectId: scheme.guid
     })
   },
@@ -200,6 +201,7 @@ const schema = {
 
   fetchTags: {
     query: Joi.object({
+      bucketId: scheme.guid,
       objectId: scheme.guid,
       tagset: type.tagset(),
     })

--- a/app/tests/unit/services/metadata.spec.js
+++ b/app/tests/unit/services/metadata.spec.js
@@ -177,7 +177,7 @@ describe('fetchMetadataForObject', () => {
 
     expect(ObjectModel.query).toHaveBeenCalledTimes(1);
     expect(ObjectModel.select).toHaveBeenCalledTimes(1);
-    expect(ObjectModel.select).toHaveBeenCalledWith('object.id AS objectId');
+    expect(ObjectModel.select).toHaveBeenCalledWith('object.id AS objectId', 'object.bucketId as bucketId');
     expect(ObjectModel.allowGraph).toHaveBeenCalledTimes(1);
     expect(ObjectModel.allowGraph).toHaveBeenCalledWith('version.metadata');
     expect(ObjectModel.withGraphJoined).toHaveBeenCalledTimes(1);
@@ -185,7 +185,7 @@ describe('fetchMetadataForObject', () => {
     expect(ObjectModel.modifyGraph).toHaveBeenCalledTimes(2);
     expect(ObjectModel.modifyGraph).toHaveBeenCalledWith('version', expect.anything());
     expect(ObjectModel.modifyGraph).toHaveBeenCalledWith('version.metadata', expect.anything());
-    expect(ObjectModel.modify).toHaveBeenCalledTimes(2);
+    expect(ObjectModel.modify).toHaveBeenCalledTimes(3);
     expect(ObjectModel.modify).toHaveBeenCalledWith('filterIds', params.objId);
     expect(ObjectModel.modify).toHaveBeenCalledWith('hasPermission', params.userId, 'READ');
     expect(ObjectModel.then).toHaveBeenCalledTimes(1);

--- a/app/tests/unit/services/tag.spec.js
+++ b/app/tests/unit/services/tag.spec.js
@@ -252,13 +252,13 @@ describe('fetchTagsForObject', () => {
 
     expect(ObjectModel.query).toHaveBeenCalledTimes(1);
     expect(ObjectModel.select).toHaveBeenCalledTimes(1);
-    expect(ObjectModel.select).toBeCalledWith('object.id AS objectId');
+    expect(ObjectModel.select).toBeCalledWith('object.id AS objectId', 'object.bucketId as bucketId');
     expect(ObjectModel.allowGraph).toHaveBeenCalledTimes(1);
     expect(ObjectModel.allowGraph).toBeCalledWith('version.tag');
     expect(ObjectModel.withGraphJoined).toHaveBeenCalledTimes(1);
     expect(ObjectModel.withGraphJoined).toBeCalledWith('version.tag');
     expect(ObjectModel.modifyGraph).toHaveBeenCalledTimes(2);
-    expect(ObjectModel.modify).toHaveBeenCalledTimes(2);
+    expect(ObjectModel.modify).toHaveBeenCalledTimes(3);
     expect(ObjectModel.modify).toBeCalledWith('filterIds', [SYSTEM_USER]);
     expect(ObjectModel.then).toHaveBeenCalledTimes(1);
   });


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

supports ticket: https://apps.nrs.gov.bc.ca/int/jira/browse/SHOWCASE-3289

- modify api spec to allow filtering by bucket when fetching tags/metadata for objects.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [ ] I have checked that unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->