### PR TITLE
Implement PUT based createObject and updateObject endpoints

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -16,6 +16,7 @@
         "busboy": "^1.6.0",
         "compression": "^1.7.4",
         "config": "^3.3.9",
+        "content-disposition": "^0.5.4",
         "cors": "^2.8.5",
         "date-fns": "^2.30.0",
         "express": "^4.18.2",

--- a/app/package.json
+++ b/app/package.json
@@ -36,6 +36,7 @@
     "busboy": "^1.6.0",
     "compression": "^1.7.4",
     "config": "^3.3.9",
+    "content-disposition": "^0.5.4",
     "cors": "^2.8.5",
     "date-fns": "^2.30.0",
     "express": "^4.18.2",

--- a/app/src/controllers/object.js
+++ b/app/src/controllers/object.js
@@ -338,6 +338,7 @@ const controller = {
 
   /**
    * @function createObjectPost
+   * @deprecated
    * Creates a new object
    * @param {object} req Express request object
    * @param {object} res Express response object
@@ -1157,6 +1158,7 @@ const controller = {
 
   /**
    * @function updateObjectPost
+   * @deprecated
    * Creates an updated version of the object via streaming
    * @param {object} req Express request object
    * @param {object} res Express response object

--- a/app/src/docs/v1.api-spec.yaml
+++ b/app/src/docs/v1.api-spec.yaml
@@ -19,20 +19,17 @@ security:
     OpenID: []
 tags:
   - name: Bucket
-    description: >-
-      Operations for managing S3 Bucket(s).
+    description: Operations for managing S3 Bucket(s).
     externalDocs:
       url: >-
         https://github.com/bcgov/common-object-management-service/wiki/Endpoint-Notes#bucket
   - name: Metadata
-    description: >-
-      Operations for managing Metadata for S3 Objects.
+    description: Operations for managing Metadata for S3 Objects.
     externalDocs:
       url: >-
         https://github.com/bcgov/common-object-management-service/wiki/Endpoint-Notes#metadata
   - name: Object
-    description: >-
-      Operations directly influencing an S3 Object.
+    description: Operations directly influencing an S3 Object.
     externalDocs:
       url: >-
         https://github.com/bcgov/common-object-management-service/wiki/Endpoint-Notes#object
@@ -42,14 +39,12 @@ tags:
       url: >-
         https://github.com/bcgov/common-object-management-service/wiki/Endpoint-Notes#permission
   - name: Tagging
-    description: >-
-      Operations for managing Tags for S3 Objects.
+    description: Operations for managing Tags for S3 Objects.
     externalDocs:
       url: >-
         https://github.com/bcgov/common-object-management-service/wiki/Endpoint-Notes#tag
   - name: User
-    description: >-
-      Operations to list valid queryable users and identity providers.
+    description: Operations to list valid queryable users and identity providers.
     externalDocs:
       url: >-
         https://github.com/bcgov/common-object-management-service/wiki/Endpoint-Notes#user
@@ -225,7 +220,7 @@ paths:
         default:
           $ref: "#/components/responses/Error"
   /object:
-    post:
+    put:
       summary: Creates an object
       description: >-
         Creates an object in the bucket specified with bucketId parameter or
@@ -236,6 +231,74 @@ paths:
         not already exist in the destination bucket and path. Existing objects
         should be managed with the updateObject endpoint instead.
       operationId: createObject
+      tags:
+        - Object
+      parameters:
+        - $ref: "#/components/parameters/Header-ContentDisposition"
+        - $ref: "#/components/parameters/Header-ContentLength"
+        - $ref: "#/components/parameters/Header-ContentType"
+        - $ref: "#/components/parameters/Header-Metadata"
+        - $ref: "#/components/parameters/Query-TagSet"
+        - in: query
+          name: bucketId
+          description: Uuid representing the bucket
+          schema:
+            type: string
+            format: uuid
+            example: ac246e31-c807-496c-bc93-cd8bc2f1b2b4
+      requestBody:
+        description: Raw binary representation of the file
+        required: true
+        content:
+          "*/*":
+            schema:
+              type: string
+              description: >-
+                Contains the binary representation of the file to upload.
+                Maximum filesize of 50GB.
+              format: binary
+              maxLength: 53687091200
+      responses:
+        "200":
+          description: Returns the created object data
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Response-ObjectDetails"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "409":
+          description: Conflict. Bucket already contains the object
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Response-Conflict"
+        "411":
+          $ref: "#/components/responses/LengthRequired"
+        "413":
+          $ref: "#/components/responses/ContentTooLarge"
+        "415":
+          $ref: "#/components/responses/UnsupportedMediaType"
+        "422":
+          $ref: "#/components/responses/UnprocessableEntity"
+        default:
+          $ref: "#/components/responses/Error"
+    post:
+      deprecated: true
+      summary: Creates an object
+      description: >-
+        Creates an object in the bucket specified with bucketId parameter or
+        default bucket configured. If COMS is running in either 'OIDC' or 'Full'
+        mode, any objects created with OIDC user authentication will have all
+        object permissions assigned to them by default. This endpoint will do a
+        best attempt effort to create the object as requested as long as it does
+        not already exist in the destination bucket and path. Existing objects
+        should be managed with the updateObject endpoint instead.
+      operationId: createObjectPost
       tags:
         - Object
       parameters:
@@ -434,13 +497,68 @@ paths:
           $ref: "#/components/responses/Forbidden"
         default:
           $ref: "#/components/responses/Error"
-    post:
+    put:
       summary: Updates an object
       description: >-
         Updates the object in the configured object storage. If the object
         storage supports versioning, a new version will be generated instead of
         overwriting the existing contents.
       operationId: updateObject
+      tags:
+        - Object
+      parameters:
+        - $ref: "#/components/parameters/Header-ContentLength"
+        - $ref: "#/components/parameters/Header-ContentType"
+        - $ref: "#/components/parameters/Header-Metadata"
+        - $ref: "#/components/parameters/Path-ObjectId"
+        - $ref: "#/components/parameters/Query-TagSet"
+      requestBody:
+        description: Raw binary representation of the file
+        required: true
+        content:
+          "*/*":
+            schema:
+              type: string
+              description: >-
+                Contains the binary representation of the file to upload.
+                Maximum filesize of 50GB.
+              format: binary
+              maxLength: 53687091200
+      responses:
+        "200":
+          description: Returns the updated object data
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Response-ObjectDetails"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "409":
+          description: Conflict. Bucket does not contain the existing object
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Response-Conflict"
+        "411":
+          $ref: "#/components/responses/LengthRequired"
+        "413":
+          $ref: "#/components/responses/ContentTooLarge"
+        "422":
+          $ref: "#/components/responses/UnprocessableEntity"
+        default:
+          $ref: "#/components/responses/Error"
+    post:
+      deprecated: true
+      summary: Updates an object
+      description: >-
+        Updates the object in the configured object storage. If the object
+        storage supports versioning, a new version will be generated instead of
+        overwriting the existing contents.
+      operationId: updateObjectPost
       tags:
         - Object
       parameters:
@@ -1274,7 +1392,9 @@ components:
       description: Specifies presentational information for the object
       schema:
         type: string
-      example: attachment; filename="foobar.txt"
+      example: >-
+        attachment; filename="bittercherrytree.txt"
+        filename*="UTF-8''skwc%E2%80%99%D3%99nj%C3%AD%C5%82c.txt"
     Content-Length:
       description: Size of the body in bytes
       schema:
@@ -1329,6 +1449,37 @@ components:
         type: string
       example: foobar.txt
   parameters:
+    Header-ContentDisposition:
+      in: header
+      name: Content-Disposition
+      required: true
+      schema:
+        type: string
+        description: >-
+          A valid RFC 6266 header. Must be of type `attachment` with either a
+          `filename` or `filename*` parameter using the encoding defined in RFC
+          8187 (normally UTF-8). For example, `skwc’әnjíłc.txt` must be
+          represented as a url-encoded string
+          `skwc%E2%80%99%D3%99nj%C3%AD%C5%82c.txt`.
+        example: >-
+          attachment; filename="bittercherrytree.txt"
+          filename*="UTF-8''skwc%E2%80%99%D3%99nj%C3%AD%C5%82c.txt"
+    Header-ContentLength:
+      in: header
+      name: Content-Length
+      required: true
+      schema:
+        type: integer
+        description: A valid RFC 2616 header. Must be present for PUT requests.
+        example: 3495
+    Header-ContentType:
+      in: header
+      name: Content-Type
+      schema:
+        type: string
+        description: A valid RFC 2045 MIME type
+        default: application/octet-stream
+        example: application/octet-stream
     Header-Metadata:
       in: header
       name: x-amz-meta-*
@@ -2159,6 +2310,19 @@ components:
               example: 403
             detail:
               example: User lacks permission to complete this action
+    Response-LengthRequired:
+      title: Length Required
+      type: object
+      allOf:
+        - $ref: "#/components/schemas/Response-Problem"
+        - type: object
+          properties:
+            status:
+              example: 411
+            title:
+              example: Length Required
+            type:
+              example: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/411
     Response-NotFound:
       title: Response Not Found
       type: object
@@ -2310,6 +2474,19 @@ components:
               example: 401
             detail:
               example: Invalid authorization credentials
+    Response-UnsupportedMediaType:
+      title: Unsupported Media Type
+      type: object
+      allOf:
+        - $ref: "#/components/schemas/Response-Problem"
+        - type: object
+          properties:
+            status:
+              example: 415
+            title:
+              example: Unsupported Media Type
+            type:
+              example: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/415
     Response-ValidationError:
       title: Response Validation Error
       type: object
@@ -2561,6 +2738,12 @@ components:
         application/json:
           schema:
             $ref: "#/components/schemas/Response-Forbidden"
+    LengthRequired:
+      description: Length Required
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Response-LengthRequired"
     NoContent:
       description: No Content
     NotFound:
@@ -2596,6 +2779,12 @@ components:
         application/json:
           schema:
             $ref: "#/components/schemas/Response-ValidationError"
+    UnsupportedMediaType:
+      description: Unsupported Media Type
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Response-UnsupportedMediaType"
   securitySchemes:
     BasicAuth:
       type: http

--- a/app/src/middleware/upload.js
+++ b/app/src/middleware/upload.js
@@ -17,16 +17,19 @@ const currentUpload = (strict = false) => {
     if (!contentLength) return new Problem(411, { detail: 'Content-Length must be greater than 0' }).send(res);
 
     // Check Content-Disposition Header
-    const disposition = req.get('Content-Disposition');
     let filename;
-    if (strict && !disposition) return new Problem(415, { detail: 'Content-Disposition header missing' }).send(res);
-    try {
-      const { type, parameters } = contentDisposition.parse(disposition);
-      if (strict && !type || type !== 'attachment') return new Error('Disposition type is not \'attachment\'');
-      if (strict && !parameters?.filename) return new Error('Disposition missing \'filename\' parameter');
-      filename = parameters?.filename;
-    } catch (e) {
-      return new Problem(400, { detail: `Content-Disposition header error: ${e.message}` }).send(res);
+    const disposition = req.get('Content-Disposition');
+    if (disposition) {
+      try {
+        const { type, parameters } = contentDisposition.parse(disposition);
+        if (strict && !type || type !== 'attachment') return new Error('Disposition type is not \'attachment\'');
+        if (strict && !parameters?.filename) return new Error('Disposition missing \'filename\' parameter');
+        filename = parameters?.filename;
+      } catch (e) {
+        return new Problem(400, { detail: `Content-Disposition header error: ${e.message}` }).send(res);
+      }
+    } else {
+      if (strict) return new Problem(415, { detail: 'Content-Disposition header missing' }).send(res);
     }
 
     // Check Content-Type Header

--- a/app/src/middleware/upload.js
+++ b/app/src/middleware/upload.js
@@ -1,0 +1,47 @@
+const Problem = require('api-problem');
+const contentDisposition = require('content-disposition');
+
+/**
+ * @function currentUpload
+ * Injects a currentUpload object to the request based on incoming headers
+ * @param {boolean} [strict=false] Short circuit returns response if misformatted
+ * @param {object} _res Express response object
+ * @param {function} next The next callback function
+ * @returns {function} Express middleware function
+ */
+const currentUpload = (strict = false) => {
+  return (req, res, next) => {
+    // Check Content-Length Header
+    const contentLength = parseInt(req.get('Content-Length'));
+    // TODO: Figure out what's killing and returning a 400 in response stack
+    if (!contentLength) return new Problem(411, { detail: 'Content-Length must be greater than 0' }).send(res);
+
+    // Check Content-Disposition Header
+    const disposition = req.get('Content-Disposition');
+    let filename;
+    if (strict && !disposition) return new Problem(415, { detail: 'Content-Disposition header missing' }).send(res);
+    try {
+      const { type, parameters } = contentDisposition.parse(disposition);
+      if (strict && !type || type !== 'attachment') return new Error('Disposition type is not \'attachment\'');
+      if (strict && !parameters?.filename) return new Error('Disposition missing \'filename\' parameter');
+      filename = parameters?.filename;
+    } catch (e) {
+      return new Problem(400, { detail: `Content-Disposition header error: ${e.message}` }).send(res);
+    }
+
+    // Check Content-Type Header
+    const mimeType = req.get('Content-Type');
+
+    req.currentUpload = Object.freeze({
+      contentLength: contentLength,
+      filename: filename,
+      mimeType: mimeType
+    });
+
+    next();
+  };
+};
+
+module.exports = {
+  currentUpload
+};

--- a/app/src/routes/v1/object.js
+++ b/app/src/routes/v1/object.js
@@ -14,7 +14,10 @@ router.put('/', objectValidator.createObject, requireSomeAuth, currentUpload(tru
   objectController.createObject(req, res, next);
 });
 
-/** Creates new objects */
+/**
+ * Creates new objects
+ * @deprecated
+ */
 router.post('/', objectValidator.createObject, requireSomeAuth, (req, res, next) => {
   objectController.createObjectPost(req, res, next);
 });
@@ -50,7 +53,10 @@ router.put('/:objectId', objectValidator.updateObject, requireSomeAuth, currentU
   objectController.updateObject(req, res, next);
 });
 
-/** Updates an object */
+/**
+ * Updates an object
+ * @deprecated
+ */
 router.post('/:objectId', objectValidator.updateObject, requireSomeAuth, currentObject, hasPermission(Permissions.UPDATE), (req, res, next) => {
   objectController.updateObjectPost(req, res, next);
 });

--- a/app/src/routes/v1/object.js
+++ b/app/src/routes/v1/object.js
@@ -3,14 +3,20 @@ const router = require('express').Router();
 const { Permissions } = require('../../components/constants');
 const { objectController } = require('../../controllers');
 const { objectValidator } = require('../../validators');
-const { requireSomeAuth } = require('../../middleware/featureToggle');
 const { checkAppMode, currentObject, hasPermission } = require('../../middleware/authorization');
+const { requireSomeAuth } = require('../../middleware/featureToggle');
+const { currentUpload } = require('../../middleware/upload');
 
 router.use(checkAppMode);
 
 /** Creates new objects */
-router.post('/', objectValidator.createObject, requireSomeAuth, (req, res, next) => {
+router.put('/', objectValidator.createObject, requireSomeAuth, currentUpload(true), (req, res, next) => {
   objectController.createObject(req, res, next);
+});
+
+/** Creates new objects */
+router.post('/', objectValidator.createObject, requireSomeAuth, (req, res, next) => {
+  objectController.createObjectPost(req, res, next);
 });
 
 /** Search for objects */
@@ -40,8 +46,13 @@ router.get('/:objectId', objectValidator.readObject, currentObject, hasPermissio
 });
 
 /** Updates an object */
-router.post('/:objectId', objectValidator.updateObject, requireSomeAuth, currentObject, hasPermission(Permissions.UPDATE), (req, res, next) => {
+router.put('/:objectId', objectValidator.updateObject, requireSomeAuth, currentUpload(), currentObject, hasPermission(Permissions.UPDATE), (req, res, next) => {
   objectController.updateObject(req, res, next);
+});
+
+/** Updates an object */
+router.post('/:objectId', objectValidator.updateObject, requireSomeAuth, currentObject, hasPermission(Permissions.UPDATE), (req, res, next) => {
+  objectController.updateObjectPost(req, res, next);
 });
 
 /** Deletes the object */

--- a/app/tests/unit/routes/v1/object.spec.js
+++ b/app/tests/unit/routes/v1/object.spec.js
@@ -12,8 +12,9 @@ const app = expressHelper(basePath, router);
 // Mock config library - @see {@link https://stackoverflow.com/a/64819698}
 jest.mock('config');
 
+// TODO: Repoint to PUT endpoint
 describe(`POST ${basePath}`, () => {
-  const spy = jest.spyOn(objectController, 'createObject');
+  const spy = jest.spyOn(objectController, 'createObjectPost');
 
   beforeEach(() => {
     spy.mockReset();


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

<!-- Describe your changes in detail -->
This breaking API change prepares us to be able to more reliably handle larger files by making our endpoint behave more closely with what S3 does for REST based S3 file uploads. The main reason we are changing the API shape is so that we can have an accurate Content-Length to describe the incoming file bytestream; our previous formdata approach did not allow us to get an accurate count, which is needed for many S3 operations.
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
[SHOWCASE-3298](https://apps.nrs.gov.bc.ca/int/jira/browse/SHOWCASE-3298)
[SHOWCASE-3300](https://apps.nrs.gov.bc.ca/int/jira/browse/SHOWCASE-3300)

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
New feature (non-breaking change which adds functionality)
<!-- Documentation (non-breaking change with enhancements to documentation) -->
Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->