### PR TITLE
Increase S3 upload limit from 50GB to 5TB

### DIFF
--- a/app/src/components/constants.js
+++ b/app/src/components/constants.js
@@ -46,13 +46,14 @@ module.exports = Object.freeze({
    */
   EMAILREGEX: '^[a-zA-Z0-9.!#$%&’*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\\.[a-zA-Z0-9-]{2,})+$',
 
-  /** Maximum Content Length supported by S3 CopyObjectCommand */
-  MAXCOPYOBJECTLENGTH: 5 * 1024 * 1024 * 1024,
+  /** Maximum number of parts supported by lib-storage upload */
+  MAXPARTCOUNT: 10000,
 
   /** Maximum Content Length supported by S3 CopyObjectCommand */
-  // TODO: Increase from current 50GB to S3 5TB once dynamic part calculation is implemented
-  // MAXFILEOBJECTLENGTH: 5 * 1024 * 1024 * 1024 * 1024,
-  MAXFILEOBJECTLENGTH: 50 * 1024 * 1024 * 1024,
+  MAXCOPYOBJECTLENGTH: 5 * 1024 * 1024 * 1024, // 5 GB
+
+  /** Maximum Content Length supported by S3 CopyObjectCommand */
+  MAXFILEOBJECTLENGTH: 5 * 1024 * 1024 * 1024 * 1024, // 5 TB
 
   /** Allowable values for the Metadata Directive parameter */
   MetadataDirective: {
@@ -61,6 +62,9 @@ module.exports = Object.freeze({
     /** All original metadata is replaced by the metadata you specify. */
     REPLACE: 'REPLACE'
   },
+
+  /** Minimum part size supported by lib-storage upload */
+  MINPARTSIZE: 5 * 1024 * 1024, // 5 MB
 
   /** Allowable values for the Tagging Directive parameter */
   TaggingDirective: {

--- a/app/src/components/utils.js
+++ b/app/src/components/utils.js
@@ -3,7 +3,7 @@ const config = require('config');
 const { existsSync, readFileSync } = require('fs');
 const { join } = require('path');
 
-const { AuthMode, AuthType, DEFAULTREGION } = require('./constants');
+const { AuthMode, AuthType, DEFAULTREGION, MAXPARTCOUNT, MINPARTSIZE } = require('./constants');
 const log = require('./log')(module.filename);
 
 const DELIMITER = '/';
@@ -20,6 +20,17 @@ const utils = {
       return `${str.slice(0, 8)}-${str.slice(8, 12)}-${str.slice(12, 16)}-${str.slice(16, 20)}-${str.slice(20)}`.toLowerCase();
     }
     else return str;
+  },
+
+  /**
+   * @function calculatePartSize
+   * Calculates the smallest feasible part size rounded to the nearest 5MB boundary
+   * @param {number} length The incoming file length
+   * @returns {number | undefined} The part size to use for this file length
+   */
+  calculatePartSize(length) {
+    if (!length || typeof length !== 'number') return undefined;
+    return Math.ceil(length / (MAXPARTCOUNT * MINPARTSIZE)) * MINPARTSIZE;
   },
 
   /**

--- a/app/src/docs/v1.api-spec.yaml
+++ b/app/src/docs/v1.api-spec.yaml
@@ -255,9 +255,9 @@ paths:
               type: string
               description: >-
                 Contains the binary representation of the file to upload.
-                Maximum filesize of 50GB.
+                Maximum filesize of 5TB.
               format: binary
-              maxLength: 53687091200
+              maxLength: 5497558138880
       responses:
         "200":
           description: Returns the created object data
@@ -323,9 +323,9 @@ paths:
                   type: string
                   description: >-
                     Contains the binary representation of the file to upload.
-                    Maximum filesize of 50GB.
+                    Maximum filesize of 5TB.
                   format: binary
-                  maxLength: 53687091200
+                  maxLength: 5497558138880
       responses:
         "200":
           description: Returns the created object data
@@ -521,9 +521,9 @@ paths:
               type: string
               description: >-
                 Contains the binary representation of the file to upload.
-                Maximum filesize of 50GB.
+                Maximum filesize of 5TB.
               format: binary
-              maxLength: 53687091200
+              maxLength: 5497558138880
       responses:
         "200":
           description: Returns the updated object data
@@ -577,9 +577,9 @@ paths:
                   type: string
                   description: >-
                     Contains the binary representation of the file to upload.
-                    Maximum filesize of 50GB.
+                    Maximum filesize of 5TB.
                   format: binary
-                  maxLength: 53687091200
+                  maxLength: 5497558138880
       responses:
         "200":
           description: Returns the updated object data
@@ -1393,12 +1393,13 @@ components:
       schema:
         type: string
       example: >-
-        attachment; filename="bittercherrytree.txt"
-        filename*="UTF-8''skwc%E2%80%99%D3%99nj%C3%AD%C5%82c.txt"
+        attachment; filename=bittercherrytree.txt;
+        filename*=UTF-8''skwc%E2%80%99%D3%99nj%C3%AD%C5%82c.txt
     Content-Length:
-      description: Size of the body in bytes
+      description: Size of the file body in bytes
       schema:
         type: integer
+        maximum: 5497558138880
       example: 529
     Content-Type:
       description: A standard MIME type describing the format of the object data
@@ -1462,8 +1463,8 @@ components:
           represented as a url-encoded string
           `skwc%E2%80%99%D3%99nj%C3%AD%C5%82c.txt`.
         example: >-
-          attachment; filename="bittercherrytree.txt"
-          filename*="UTF-8''skwc%E2%80%99%D3%99nj%C3%AD%C5%82c.txt"
+          attachment; filename=bittercherrytree.txt;
+          filename*=UTF-8''skwc%E2%80%99%D3%99nj%C3%AD%C5%82c.txt
     Header-ContentLength:
       in: header
       name: Content-Length
@@ -1471,6 +1472,7 @@ components:
       schema:
         type: integer
         description: A valid RFC 2616 header. Must be present for PUT requests.
+        maximum: 5497558138880
         example: 3495
     Header-ContentType:
       in: header
@@ -1615,7 +1617,9 @@ components:
       description: The object MIME Type
       schema:
         type: string
-        example: application/octet-stream
+        description: The object MIME Type
+        default: application/octet-stream
+        example: text/plain
     Query-ObjectId:
       in: query
       name: objectId
@@ -2102,7 +2106,8 @@ components:
             mimeType:
               type: string
               description: The MIME Type of the version
-              example: application/octet-stream
+              default: application/octet-stream
+              example: text/plain
             deleteMarker:
               type: boolean
               description: Whether or not this version is a S3 delete-marker
@@ -2366,22 +2371,29 @@ components:
       title: Response Object Details
       type: object
       allOf:
+        - $ref: "#/components/schemas/DB-Object"
         - type: object
           required:
+            - length
             - mimeType
             - Key
             - Location
           properties:
+            length:
+              type: integer
+              description: Size of the file body in bytes
+              maximum: 5497558138880
+              example: 529
             mimeType:
               type: string
               description: The object MIME Type
+              default: application/octet-stream
               example: text/plain
             versionId:
               type: string
               description: The primary identifier for this version in the COMS database
               format: uuid
               example: ac246e31-c807-496c-bc93-cd8bc2f1b2b4
-        - $ref: "#/components/schemas/DB-Object"
         - $ref: "#/components/schemas/DB-Metadata"
         - $ref: "#/components/schemas/DB-Tags"
         - $ref: "#/components/schemas/S3-Object"

--- a/app/src/middleware/upload.js
+++ b/app/src/middleware/upload.js
@@ -22,18 +22,19 @@ const currentUpload = (strict = false) => {
     if (disposition) {
       try {
         const { type, parameters } = contentDisposition.parse(disposition);
-        if (strict && !type || type !== 'attachment') return new Error('Disposition type is not \'attachment\'');
-        if (strict && !parameters?.filename) return new Error('Disposition missing \'filename\' parameter');
+        if (strict && !type || type !== 'attachment') throw new Error('Disposition type is not \'attachment\'');
+        if (strict && !parameters?.filename) throw new Error('Disposition missing \'filename\' parameter');
         filename = parameters?.filename;
       } catch (e) {
-        return new Problem(400, { detail: `Content-Disposition header error: ${e.message}` }).send(res);
+        // Ignore improperly formatted Content-Disposition when not in strict mode
+        if (strict) return new Problem(400, { detail: `Content-Disposition header error: ${e.message}` }).send(res);
       }
     } else {
       if (strict) return new Problem(415, { detail: 'Content-Disposition header missing' }).send(res);
     }
 
     // Check Content-Type Header
-    const mimeType = req.get('Content-Type');
+    const mimeType = req.get('Content-Type') ?? 'application/octet-stream';
 
     req.currentUpload = Object.freeze({
       contentLength: contentLength,

--- a/app/src/services/storage.js
+++ b/app/src/services/storage.js
@@ -423,13 +423,14 @@ const objectStorageService = {
    * Uploads the object `stream` at the `id` path
    * @param {stream} options.stream The binary stream of the object
    * @param {string} options.name The file name of the object
+   * @param {number} options.length The content length of the object
    * @param {string} options.mimeType The mime type of the object
    * @param {object} [options.metadata] Optional object containing key/value pairs for metadata
    * @param {object} [options.tags] Optional object containing key/value pairs for tags
    * @param {string} [options.bucketId] Optional bucketId
    * @returns {Promise<CompleteMultipartUploadCommandOutput | AbortMultipartUploadCommandOutput>} The response of the put object operation
    */
-  async upload({ stream, name, mimeType, metadata, tags, bucketId = undefined }) {
+  async upload({ stream, name, length, mimeType, metadata, tags, bucketId = undefined }) {
     const data = await utils.getBucket(bucketId);
 
     const upload = new Upload({
@@ -444,8 +445,7 @@ const objectStorageService = {
         // TODO: Consider adding API param support for Server Side Encryption
         // ServerSideEncryption: 'AES256'
       },
-      // TODO: Add utility to determine optimal part size based on content length
-      // partSize: 512 * 1024 * 1024,
+      partSize: utils.calculatePartSize(length),
       queueSize: 1
     });
 

--- a/app/tests/unit/components/utils.spec.js
+++ b/app/tests/unit/components/utils.spec.js
@@ -32,6 +32,27 @@ describe('addDashesToUuid', () => {
   });
 });
 
+describe('calculatePartSize', () => {
+  it.each([
+    [undefined, undefined],
+    [undefined, null],
+    [undefined, 'foo'],
+    [undefined, []],
+    [undefined, {}],
+    [undefined, 0],
+    [5242880, 1],
+    [5242880, 5242880], // 5MB
+    [5242880, 5368709120], // 5GB
+    [5242880, 52428800000], // ~50GB
+    [10485760, 52428800001], // ~50GB
+    [10485760, 104857600000], // ~100GB
+    [15728640, 104857600001], // ~100GB
+    [550502400, 5497558138880], // 5TB
+  ])('should return %o given %j', (expected, length) => {
+    expect(utils.calculatePartSize(length)).toEqual(expected);
+  });
+});
+
 // TODO: Deprecated, to remove this
 describe('getPath', () => {
   const delimitSpy = jest.spyOn(utils, 'delimit');

--- a/app/tests/unit/middleware/upload.spec.js
+++ b/app/tests/unit/middleware/upload.spec.js
@@ -1,0 +1,65 @@
+const Problem = require('api-problem');
+
+const { currentUpload } = require('../../../src/middleware/upload');
+
+beforeEach(() => {
+  jest.resetAllMocks();
+});
+
+afterAll(() => {
+  jest.restoreAllMocks();
+});
+
+describe('currentUpload', () => {
+  const problemSendSpy = jest.spyOn(Problem.prototype, 'send');
+
+  let req, res, next;
+
+  beforeEach(() => {
+    problemSendSpy.mockImplementation(() => { });
+
+    req = { get: jest.fn() };
+    res = {};
+    next = jest.fn();
+  });
+
+  it.each([
+    [0, undefined, false, undefined, undefined, undefined],
+    [0, undefined, false, 0, undefined, undefined],
+    [1, { contentLength: 539, filename: undefined, mimeType: 'application/octet-stream' }, false, 539, undefined, undefined],
+    [1, { contentLength: 539, filename: undefined, mimeType: 'application/octet-stream' }, false, 539, 'inline', undefined],
+    [1, { contentLength: 539, filename: undefined, mimeType: 'application/octet-stream' }, false, 539, 'xattachment', undefined],
+    [1, { contentLength: 539, filename: undefined, mimeType: 'application/octet-stream' }, false, 539, 'attachment; xfilename="foo.txt"', undefined],
+    [1, { contentLength: 539, filename: 'foo.txt', mimeType: 'application/octet-stream' }, false, 539, 'attachment; filename="foo.txt"', undefined],
+    [1, { contentLength: 539, filename: 'foo.txt', mimeType: 'text/plain' }, false, 539, 'attachment; filename="foo.txt"', 'text/plain'],
+    [1, { contentLength: 539, filename: 'föo.txt', mimeType: 'text/plain' }, false, 539, 'attachment; filename=foo.txt; filename*=UTF-8\'\'f%C3%B6o.txt', 'text/plain'],
+    [1, { contentLength: 539, filename: 'föo.txt', mimeType: 'text/plain' }, false, 539, 'attachment; filename*=UTF-8\'\'f%C3%B6o.txt; filename=foo.txt', 'text/plain'],
+    [0, undefined, true, undefined, undefined, undefined],
+    [0, undefined, true, 0, undefined, undefined],
+    [0, undefined, true, 539, undefined, undefined],
+    [0, undefined, true, 539, 'inline', undefined],
+    [0, undefined, true, 539, 'xattachment', undefined],
+    [0, undefined, true, 539, 'attachment; xfilename="foo.txt"', undefined],
+    [1, { contentLength: 539, filename: 'foo.txt', mimeType: 'application/octet-stream' }, true, 539, 'attachment; filename="foo.txt"', undefined],
+    [1, { contentLength: 539, filename: 'foo.txt', mimeType: 'text/plain' }, true, 539, 'attachment; filename="foo.txt"', 'text/plain'],
+    [1, { contentLength: 539, filename: 'föo.txt', mimeType: 'text/plain' }, true, 539, 'attachment; filename=foo.txt; filename*=UTF-8\'\'f%C3%B6o.txt', 'text/plain'],
+    [1, { contentLength: 539, filename: 'föo.txt', mimeType: 'text/plain' }, true, 539, 'attachment; filename*=UTF-8\'\'f%C3%B6o.txt; filename=foo.txt', 'text/plain']
+  ])('should call next %i times with currentUpload %j given strict %j, length %j, disposition %j and type %j', (nextCount, current, strict, length, disposition, type) => {
+    const sendCount = 1 - nextCount;
+
+    req.get.mockReturnValueOnce(length); // contentlength
+    req.get.mockReturnValueOnce(disposition); // contentdisposition
+    req.get.mockReturnValueOnce(type); // contenttype
+
+    const result = currentUpload(strict);
+    expect(result).toBeInstanceOf(Function);
+    result(req, res, next);
+
+    expect(req.currentUpload).toEqual(current);
+    expect(next).toHaveBeenCalledTimes(nextCount);
+    if (nextCount) expect(next).toHaveBeenCalledWith();
+    expect(problemSendSpy).toHaveBeenCalledTimes(sendCount);
+    if (sendCount) expect(problemSendSpy).toHaveBeenCalledWith(res);
+  });
+});
+


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

<!-- Describe your changes in detail -->
This PR addresses the need to dynamically calculate the S3 multipart upload part size as the payload gets larger. It also addresses some bugfixes caught by unit testing and a few minor typos in the OpenAPI spec.
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
[SHOWCASE-3300](https://apps.nrs.gov.bc.ca/int/jira/browse/SHOWCASE-3300)

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
New feature (non-breaking change which adds functionality)
Documentation (non-breaking change with enhancements to documentation)
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->