### PR TITLE
Ensure coms-id tags buried in history are used when soft-deleted

### DIFF
--- a/app/src/components/utils.js
+++ b/app/src/components/utils.js
@@ -310,7 +310,7 @@ const utils = {
     const pathParts = path.split(DELIMITER).filter(part => part);
     const prefixParts = prefix.split(DELIMITER).filter(part => part);
     return prefixParts.every((part, i) => pathParts[i] === part)
-      && pathParts.filter(part => !prefixParts.includes(part)).length === 1;
+      && pathParts.filter(part => !prefixParts.includes(part)).length < 2;
   },
 
   /**

--- a/app/src/controllers/sync.js
+++ b/app/src/controllers/sync.js
@@ -20,15 +20,13 @@ const controller = {
    */
   async syncBucket(req, res, next) {
     try {
-      const allMode = isTruthy(req.query.all);
+      // TODO: Consider adding an "all" mode for checking through all known objects and buckets for job enumeration
+      // const allMode = isTruthy(req.query.all);
       const bucketId = addDashesToUuid(req.params.bucketId);
       const userId = await userService.getCurrentUserId(getCurrentIdentity(req.currentUser, SYSTEM_USER), SYSTEM_USER);
 
-      const dbParams = {};
-      if (!allMode) dbParams.bucketId = bucketId;
-
       const [dbResponse, s3Response] = await Promise.all([
-        objectService.searchObjects(dbParams),
+        objectService.searchObjects({ bucketId: bucketId }),
         storageService.listAllObjectVersions({ bucketId: bucketId, filterLatest: true })
       ]);
 

--- a/app/src/services/storage.js
+++ b/app/src/services/storage.js
@@ -47,7 +47,7 @@ const objectStorageService = {
    */
   _getS3Client: ({ accessKeyId, endpoint, region, secretAccessKey } = {}) => {
     if (!accessKeyId || !endpoint || !region || !secretAccessKey) {
-      log.error('Unable to generate S3Client due to missing arguments', { function: '_getS3Client'});
+      log.error('Unable to generate S3Client due to missing arguments', { function: '_getS3Client' });
     }
 
     return new S3Client({

--- a/app/src/services/sync.js
+++ b/app/src/services/sync.js
@@ -208,7 +208,7 @@ const service = {
       // await call to get versions from both the COMS db and S3
       const [comsVersionPromise, s3VersionPromise] = await Promise.allSettled([
         Version.query(trx).modify('filterObjectId', object.id).orderBy('createdAt', 'desc'),
-        storageService.listObjectVersion({ filePath: object.path, bucketId: object.bucketId })
+        storageService.listAllObjectVersions({ filePath: object.path, bucketId: object.bucketId })
       ]);
 
       // COMS versions

--- a/app/tests/unit/components/utils.spec.js
+++ b/app/tests/unit/components/utils.spec.js
@@ -455,11 +455,13 @@ describe('isAtPath', () => {
   it.each([
     [false, undefined, undefined],
     [false, null, null],
-    [false, '', ''],
+    [true, '', ''], // Root level empty string identies should technically be true
     [true, '', 'file'],
     [false, '', 'file/bleep'],
     [true, '/', 'file'],
     [false, '/', 'file/bleep'],
+    [true, 'foo', 'foo'], // Root level file identies should be true
+    [false, 'foo', 'bar'], // Non-matching root level path and prefix should be false
     [true, 'foo', 'foo/bar'],
     [true, 'foo', '/foo/bar'],
     [true, '/foo', 'foo/bar'],


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

<!-- Describe your changes in detail -->
This PR focuses on making sure that when objects are soft deleted that their previous coms-id values are still used during synchronization where appropriate.

- 50f62e4 Implement _deriveObjectId utility synchronize method
- 58cfed0 Ensure that isAtPath utility recognizes files at root level as valid
- aff9799 Drop partial implementation of all queryparam from syncBucket controller

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
[SHOWCASE-3317](https://apps.nrs.gov.bc.ca/int/jira/browse/SHOWCASE-3317)

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
New feature (non-breaking change which adds functionality)
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->