### PR TITLE
check for undefined TagSet

### DIFF
--- a/app/src/controllers/object.js
+++ b/app/src/controllers/object.js
@@ -117,7 +117,7 @@ const controller = {
       }
       // get existing tags on source object, eg: { 'animal': 'bear', colour': 'black' }
       const sourceObject = await storageService.getObjectTagging({ filePath: objPath, s3VersionId: sourceS3VersionId, bucketId: bucketId });
-      const sourceTags = Object.assign({}, ...(sourceObject.TagSet.map(item => ({ [item.Key]: item.Value }))));
+      const sourceTags = sourceObject.TagSet ? Object.assign({}, ...(sourceObject.TagSet.map(item => ({ [item.Key]: item.Value })))) : [];
 
       const metadataToAppend = getMetadata(req.headers);
       const data = {
@@ -178,8 +178,8 @@ const controller = {
       const { TagSet: existingTags } = await storageService.getObjectTagging({ filePath: objPath, s3VersionId: sourceS3VersionId, bucketId: bucketId });
 
       const newSet = newTags
-        // Join new tags and existing tags
-        .concat(existingTags)
+        // Join new tags and existing tags if defined
+        .concat(existingTags ? existingTags : [])
         // remove existing 'coms-id' tag if it exists
         .filter(x => x.Key !== 'coms-id')
         // filter duplicates
@@ -528,7 +528,7 @@ const controller = {
         s3VersionId: sourceS3VersionId,
         bucketId: bucketId
       });
-      const sourceTags = Object.assign({}, ...(sourceObject.TagSet.map(item => ({ [item.Key]: item.Value }))));
+      const sourceTags = sourceObject.TagSet ? Object.assign({}, ...(sourceObject.TagSet.map(item => ({ [item.Key]: item.Value })))) : [];
 
       const data = {
         bucketId: bucketId,
@@ -892,7 +892,7 @@ const controller = {
         s3VersionId: sourceS3VersionId,
         bucketId: bucketId
       });
-      const sourceTags = Object.assign({}, ...(sourceObject.TagSet.map(item => ({ [item.Key]: item.Value }))));
+      const sourceTags = sourceObject.TagSet ? Object.assign({}, ...(sourceObject.TagSet.map(item => ({ [item.Key]: item.Value })))) : [];
 
       const newMetadata = getMetadata(req.headers);
 

--- a/app/src/services/sync.js
+++ b/app/src/services/sync.js
@@ -31,12 +31,12 @@ const service = {
 
     if (typeof s3Object === 'object') { // If regular S3 Object
       const { TagSet } = await storageService.getObjectTagging({ filePath: path, bucketId: bucketId });
-      const s3ObjectComsId = TagSet.find(obj => (obj.Key === 'coms-id'))?.Value;
+      const s3ObjectComsId = TagSet?.find(obj => (obj.Key === 'coms-id'))?.Value;
 
       if (s3ObjectComsId && uuidValidate(s3ObjectComsId)) {
         objId = s3ObjectComsId;
       } else { // Update S3 Object if there is still remaining space in the TagSet
-        if (TagSet.length < 10) { // putObjectTagging replaces S3 tags so new TagSet must contain existing values
+        if (TagSet?.length < 10) { // putObjectTagging replaces S3 tags so new TagSet must contain existing values
           await storageService.putObjectTagging({
             filePath: path,
             bucketId: bucketId,
@@ -53,7 +53,7 @@ const service = {
           s3VersionId: versionId,
           bucketId: bucketId
         });
-        const oldObjId = result?.TagSet.find(obj => obj.Key === 'coms-id')?.Value;
+        const oldObjId = result?.TagSet?.find(obj => obj.Key === 'coms-id')?.Value;
 
         if (oldObjId && uuidValidate(oldObjId)) {
           objId = oldObjId;
@@ -334,7 +334,7 @@ const service = {
       const s3Tags = toLowerKeys(s3TagsForVersion?.TagSet);
 
       // Ensure `coms-id` tag exists on this version in S3
-      if (s3Tags.length < 10 && !s3Tags.find(s3T => s3T.key === 'coms-id')) {
+      if (s3Tags?.length < 10 && !s3Tags.find(s3T => s3T.key === 'coms-id')) {
         await storageService.putObjectTagging({
           filePath: path,
           tags: s3TagsForVersion?.TagSet.concat([{ Key: 'coms-id', Value: comsVersion.objectId }]),
@@ -348,7 +348,7 @@ const service = {
       // Dissociate Tags not in S3
       const oldTags = [];
       for (const comsT of comsTags) {
-        if (!s3Tags.some(s3T => s3T.key === comsT.key && s3T.value === comsT.value)) {
+        if (!s3Tags?.some(s3T => s3T.key === comsT.key && s3T.value === comsT.value)) {
           oldTags.push(comsT);
         }
       }
@@ -356,7 +356,7 @@ const service = {
 
       // Associate new S3 Tags
       const newTags = [];
-      for (const s3Tag of s3Tags) {
+      for (const s3Tag of (s3Tags?.lenghth ? s3Tags : [])) {
         if (!comsTags.some(comsT => comsT.key === s3Tag.key && comsT.value === s3Tag.value)) {
           newTags.push(s3Tag);
         } else {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

- handle TagSet when undefined in S3 GetObjectTaggingCommand() response.
steps to reproduce: 
mount add an empty Dell s3 bucket to coms
upload a new file using S3 Browser/cyberduck
call coms sync for the bucket.
console shows error, new object not synced

- other coms endpoints that use this command but because we add coms-id tag by default, issue did not present.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->