### PR TITLE
Remove request timeouts for upload endpoints

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 # These users will be the default owners for everything in the repo.
 # Unless a later match takes precedence, the following users will be
 # requested for review when someone opens a pull request.
-* @jujaga @norrisng-bc @TimCsaky
+* @jujaga @norrisng-bc @TimCsaky @jatindersingh93

--- a/app/src/middleware/upload.js
+++ b/app/src/middleware/upload.js
@@ -52,6 +52,14 @@ const currentUpload = (strict = false) => {
       mimeType: mimeType
     });
 
+    /**
+     * Removes the default 5 minute request timeout added in Node v18
+     * This change reverts the behavior to be similar to Node v16 and earlier
+     * This value should not be 0x7FFFFFFF as behavior becomes unpredictable
+     * @see {@link https://nodejs.org/en/blog/release/v18.0.0#http-timeouts}
+     */
+    req.socket.server.requestTimeout = 0;
+
     next();
   };
 };

--- a/app/tests/unit/middleware/upload.spec.js
+++ b/app/tests/unit/middleware/upload.spec.js
@@ -12,7 +12,10 @@ describe('currentUpload', () => {
   let req, res, next;
 
   beforeEach(() => {
-    req = { get: jest.fn() };
+    req = {
+      get: jest.fn(),
+      socket: { server: {} }
+    };
     res = {};
     next = jest.fn();
   });
@@ -52,7 +55,10 @@ describe('currentUpload', () => {
 
     expect(req.currentUpload).toEqual(current);
     expect(next).toHaveBeenCalledTimes(nextCount);
-    if (nextCount) expect(next).toHaveBeenCalledWith();
+    if (nextCount) {
+      expect(req.socket.server.requestTimeout).toEqual(0);
+      expect(next).toHaveBeenCalledWith();
+    }
   });
 });
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

This PR sets an override of the default node http server timeouts for our two file upload endpoint requests.
The default timeout (as of node v18) for requests is 5 minutes. The new timeout value (in milliseconds) is given a more appropriate value by looking at the content length.

With this code in place, we need to ensure that a large file upload can run for more than 5 minutes. Without this fix, we were seeing it timeout around the 5m20s mark. 

My hope is that we get this merged in to our dev environment so we can test the change while introducing other factors such as:
- going via the api gateway
- using BCBox (browser) as the client
- openshift configuration 


<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->