### PR TITLE
Add ability to set database connection string

### DIFF
--- a/app/README.md
+++ b/app/README.md
@@ -54,6 +54,7 @@ The following variables configure the use of a backend database to support user-
 
 | Config Var | Env Var | Default | Notes |
 | --- | --- | --- | --- |
+| `connectionString` | `DB_CONNECTION_STRING` | coms | COMS database connection string, This setting has the highest priority to use. If not specified then connection details will be determined using the individual connection fields |
 | `database` | `DB_DATABASE` | coms | COMS database name |
 | `host` | `DB_HOST` | localhost | Database conection hostname |
 | `username` | `DB_USERNAME` | app | Database account username |

--- a/app/config/custom-environment-variables.json
+++ b/app/config/custom-environment-variables.json
@@ -5,6 +5,7 @@
     "username": "BASICAUTH_USERNAME"
   },
   "db": {
+    "connectionString": "DB_CONNECTION_STRING",
     "database": "DB_DATABASE",
     "host": "DB_HOST",
     "password": "DB_PASSWORD",

--- a/app/knexfile.js
+++ b/app/knexfile.js
@@ -33,6 +33,9 @@ const logWrapper = (level, msg) => log.log(level, msg);
 module.exports = {
   client: 'pg',
   connection: {
+    // connectionString is highest priority to use. If left unspecified then connection
+    // details will be determined using the individual connection fields (host, port, etc)
+    connectionString: config.has('db.connectionString') ? config.get('db.connectionString') : undefined,
     host: config.get('db.host'),
     user: config.get('db.username'),
     password: config.get('db.password'),


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

Adds the ability to use an optional `onnectionString` property. This would allow customizing any of the connecting string properties without having to configure each property individually. 

Fixes #220

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [ ] I have checked that unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->