### PR TITLE
Use isLatest db value in object search query

### DIFF
--- a/app/src/db/models/tables/objectModel.js
+++ b/app/src/db/models/tables/objectModel.js
@@ -103,21 +103,13 @@ class ObjectModel extends Timestamps(Model) {
             query.modifyGraph('version', builder => {
               builder
                 .select('version.*')
-                .distinctOn('version.objectId')
-                .orderBy([
-                  { column: 'version.objectId' },
-                  { column: 'version.createdAt', order: 'desc' }
-                ]);
+                .where('version.isLatest', value);
             });
           } else {
             // TODO: Consider modifying graph to join on all versions except latest
             const subquery = Version.query()
               .select('version.id')
-              .distinctOn('objectId')
-              .orderBy([
-                { column: 'objectId' },
-                { column: 'version.createdAt', order: 'desc' }
-              ]);
+              .where('version.isLatest', true);
             query.whereNotIn('version.id', builder => {
               builder.intersect(subquery);
             });


### PR DESCRIPTION
We need to update our search objects query to take advantage of the isLatest boolean we added to the db schema (previously we used createdAt date desc to work out latest).

This change fixes a bug where soft deleted files are showing up in bcbox.


<!-- Provide a general summary of your changes in the Title above -->
# Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->