### PR TITLE
Add default workspace formatters and extensions

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 # These users will be the default owners for everything in the repo.
 # Unless a later match takes precedence, the following users will be
 # requested for review when someone opens a pull request.
-* @jujaga @norrisng-bc @TimCsaky @jatindersingh93
+* @jujaga @norrisng-bc @TimCsaky @jatindersingh93 @wilwong89 @kyle1morel

--- a/.gitignore
+++ b/.gitignore
@@ -29,7 +29,6 @@ yarn-error.log*
 
 # Editor directories and files
 .idea
-.vscode
 *.iml
 *.suo
 *.ntvs*

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,11 @@
+{
+  "recommendations": [
+    "bierner.markdown-preview-github-styles",
+    "davidanson.vscode-markdownlint",
+    "dbaeumer.vscode-eslint",
+    "eamodio.gitlens",
+    "editorconfig.editorconfig",
+    "redhat.vscode-yaml",
+    "ryanluker.vscode-coverage-gutters",
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,23 @@
+{
+  "[html]": {
+    "editor.defaultFormatter": "vscode.html-language-features"
+  },
+  "[javascript]": {
+    "editor.defaultFormatter": "dbaeumer.vscode-eslint"
+  },
+  "[json]": {
+    "editor.defaultFormatter": "vscode.json-language-features"
+  },
+  "[jsonc]": {
+    "editor.defaultFormatter": "vscode.json-language-features"
+  },
+  "[typescript]": {
+    "editor.defaultFormatter": "vscode.typescript-language-features"
+  },
+  "coverage-gutters.showGutterCoverage": false,
+  "coverage-gutters.showLineCoverage": true,
+  "editor.defaultFormatter": "dbaeumer.vscode-eslint",
+  "editor.formatOnSave": true,
+  "eslint.format.enable": true,
+  "files.insertFinalNewline": true,
+}

--- a/app/.eslintrc.js
+++ b/app/.eslintrc.js
@@ -21,6 +21,7 @@ module.exports = {
       'SwitchCase': 1
     }],
     'linebreak-style': ['error', 'unix'],
+    'max-len': ['warn', { code: 120, comments: 120, ignoreUrls: true }],
     'no-console': process.env.NODE_ENV === 'production' ? 'error' : 'warn',
     'no-debugger': process.env.NODE_ENV === 'production' ? 'error' : 'warn',
     quotes: ['error', 'single'],


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

Adds workspace level default language formatters.
Adds recommended workspace vscode extensions.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
 New feature (non-breaking change which adds functionality) 
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [ ] I have checked that unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->