### PR TITLE
Ensure sync operation does not fail when unable to write tags to s3

### DIFF
--- a/app/src/services/sync.js
+++ b/app/src/services/sync.js
@@ -42,6 +42,8 @@ const service = {
             filePath: path,
             bucketId: bucketId,
             tags: TagSet.concat([{ Key: 'coms-id', Value: objId }])
+          }).catch((err) => {
+            log.warn(`Unable to add coms-id tag: ${err.message}`, { function: '_deriveObjectId' });
           });
         }
       }
@@ -354,17 +356,21 @@ const service = {
          * NOTE: adding tags to a specified version (passing a `VersionId` parameter) will affect `Last Modified`
          * attribute of multiple versions on some s3 storage providors including Dell ECS
          */
-        await storageService.putObjectTagging({
-          filePath: path,
-          tags: (s3TagsForVersion?.TagSet ?? []).concat([{
-            Key: 'coms-id',
-            Value: comsVersion.objectId
-          }]),
-          bucketId: bucketId,
-          // s3VersionId: comsVersion.s3VersionId,
-        });
-        // add to our arrays for comaprison
-        s3Tags.push({ key: 'coms-id', value: comsVersion.objectId });
+        try {
+          await storageService.putObjectTagging({
+            filePath: path,
+            tags: (s3TagsForVersion?.TagSet ?? []).concat([{
+              Key: 'coms-id',
+              Value: comsVersion.objectId
+            }]),
+            bucketId: bucketId,
+            // s3VersionId: comsVersion.s3VersionId,
+          });
+          // add to our arrays for comaprison
+          s3Tags.push({ key: 'coms-id', value: comsVersion.objectId });
+        } catch (err) {
+          log.warn(`Unable to add coms-id tag: ${err.message}`, { function: 'syncTags' });
+        }
       }
 
       // Dissociate Tags not in S3


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

<!-- Describe your changes in detail -->
There are edge case scenarios where the PutObjectTaggingCommand will fail due to some upstream S3 configuration. We want to ensure that in the event sync is unable to write a coms-id tag to an object, the overall sync operation will still carry on instead of halting and failing out.
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
[SHOWCASE-3453](https://apps.nrs.gov.bc.ca/int/jira/browse/SHOWCASE-3453)

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->