### PR TITLE
Inherit and toggle S3 ACL Public/Private permissions

### DIFF
--- a/app/src/components/constants.js
+++ b/app/src/components/constants.js
@@ -1,4 +1,7 @@
 module.exports = Object.freeze({
+  /** S3 All Users Predefined group URI */
+  ALLUSERS: 'http://acs.amazonaws.com/groups/global/AllUsers',
+
   /** Application authentication mode */
   AuthMode: {
     /** Only Basic Authentication */

--- a/app/src/controllers/object.js
+++ b/app/src/controllers/object.js
@@ -147,6 +147,9 @@ const controller = {
       const s3Response = await storageService.copyObject(data);
 
       await utils.trxWrapper(async (trx) => {
+        // set public flag to false
+        await objectService.update({ id: objId, userId: userId, path: objPath, public: false });
+
         // create or update version in DB (if a non-versioned object)
         const version = s3Response.VersionId ?
           await versionService.copy(
@@ -834,6 +837,9 @@ const controller = {
       const s3Response = await storageService.copyObject(data);
 
       await utils.trxWrapper(async (trx) => {
+        // set public flag to false
+        await objectService.update({ id: objId, userId: userId, path: objPath, public: false });
+
         // create or update version (if a non-versioned object)
         const version = s3Response.VersionId ?
           await versionService.copy(
@@ -1010,6 +1016,7 @@ const controller = {
         name: filename,
         mimeType: req.currentUpload.mimeType,
         metadata: getMetadata(req.headers),
+        public: false, // New uploads always default to private ACL status
         tags: {
           ...req.query.tagset,
           'coms-id': objId // Enforce `coms-id:<objectId>` tag

--- a/app/src/docs/v1.api-spec.yaml
+++ b/app/src/docs/v1.api-spec.yaml
@@ -323,7 +323,8 @@ paths:
         objects created with OIDC user authentication will have all object
         permissions assigned to them by default. This endpoint will do a best
         attempt effort to create the object as requested as long as it does not
-        already exist in the destination bucket and path. Existing objects should be managed with the updateObject endpoint instead.
+        already exist in the destination bucket and path. Existing objects
+        should be managed with the updateObject endpoint instead.
       operationId: createObject
       tags:
         - Object

--- a/app/src/docs/v1.api-spec.yaml
+++ b/app/src/docs/v1.api-spec.yaml
@@ -318,12 +318,12 @@ paths:
       summary: Creates an object
       description: >-
         Creates an object in the bucket specified with bucketId parameter or
-        default bucket configured. If COMS is running in either 'OIDC' or 'Full'
-        mode, any objects created with OIDC user authentication will have all
-        object permissions assigned to them by default. This endpoint will do a
-        best attempt effort to create the object as requested as long as it does
-        not already exist in the destination bucket and path. Existing objects
-        should be managed with the updateObject endpoint instead.
+        default bucket configured. The object will be toggled to private after
+        this operation. If COMS is running in either 'OIDC' or 'Full' mode, any
+        objects created with OIDC user authentication will have all object
+        permissions assigned to them by default. This endpoint will do a best
+        attempt effort to create the object as requested as long as it does not
+        already exist in the destination bucket and path. Existing objects should be managed with the updateObject endpoint instead.
       operationId: createObject
       tags:
         - Object
@@ -673,7 +673,8 @@ paths:
       description: >-
         Creates a copy and new version of the object with the given metadata
         added to the object. Multiple Key/Value pairs can be provided in the
-        header for the metadata.
+        header for the metadata. The object will be toggled to private after
+        this operation.
       operationId: addMetadata
       tags:
         - Metadata
@@ -698,7 +699,8 @@ paths:
       description: >-
         Creates a copy and new version of the object with the given metadata
         replacing the existing. Multiple Key/Value pairs can be provided in the
-        header for the metadata.
+        header for the metadata. The object will be toggled to private after
+        this operation.
       operationId: replaceMetadata
       tags:
         - Metadata

--- a/app/src/docs/v1.api-spec.yaml
+++ b/app/src/docs/v1.api-spec.yaml
@@ -646,8 +646,8 @@ paths:
     patch:
       summary: Sets the public flag of an object
       description: >-
-        Toggles the public property for an object. Sets public to false if
-        public query parameter is not specified.
+        Toggles the public property for an object and broadcasts to S3 ACL.
+        Sets public to false if public query parameter is not specified.
       operationId: togglePublic
       tags:
         - Object

--- a/app/src/services/storage.js
+++ b/app/src/services/storage.js
@@ -4,12 +4,14 @@ const {
   DeleteObjectTaggingCommand,
   GetBucketEncryptionCommand,
   GetBucketVersioningCommand,
+  GetObjectAclCommand,
   GetObjectCommand,
   GetObjectTaggingCommand,
   HeadBucketCommand,
   HeadObjectCommand,
   ListObjectsV2Command,
   ListObjectVersionsCommand,
+  PutObjectAclCommand,
   PutObjectCommand,
   PutBucketEncryptionCommand,
   PutObjectTaggingCommand,
@@ -170,6 +172,25 @@ const objectStorageService = {
     };
     const response = await this._getS3Client(data).send(new GetBucketVersioningCommand(params));
     return Promise.resolve(response.Status === 'Enabled');
+  },
+
+  /**
+   * @function getObjectAcl
+   * Gets the access control list for an object
+   * @param {string} options.filePath The filePath of the object
+   * @param {string} [options.s3VersionId] Optional version ID used to reference a speciific version of the object
+   * @param {string} [options.bucketId] Optional bucketId
+   * @returns {Promise<GetObjectAclOutput>} The response of the get object acl operation
+   * @throws If object is not found
+   */
+  async getObjectAcl({ filePath, s3VersionId = undefined, bucketId = undefined }) {
+    const data = await utils.getBucket(bucketId);
+    const params = {
+      Bucket: data.bucket,
+      Key: filePath,
+      VersionId: s3VersionId
+    };
+    return this._getS3Client(data).send(new GetObjectAclCommand(params));
   },
 
   /**
@@ -424,6 +445,27 @@ const objectStorageService = {
     };
 
     return this._getS3Client(data).send(new PutObjectCommand(params));
+  },
+
+  /**
+   * @function putObjectAcl
+   * Puts the canned access control list for an object
+   * @param {ObjectCannedACL} options.acl The acl to apply to an object
+   * @param {string} options.filePath The filePath of the object
+   * @param {string} [options.s3VersionId] Optional version ID used to reference a speciific version of the object
+   * @param {string} [options.bucketId] Optional bucketId
+   * @returns {Promise<PutObjectAclOutput>} The response of the put object acl operation
+   * @throws If object is not found
+   */
+  async putObjectAcl({ acl, filePath, s3VersionId = undefined, bucketId = undefined }) {
+    const data = await utils.getBucket(bucketId);
+    const params = {
+      ACL: acl,
+      Bucket: data.bucket,
+      Key: filePath,
+      VersionId: s3VersionId
+    };
+    return this._getS3Client(data).send(new PutObjectAclCommand(params));
   },
 
   /**

--- a/app/src/services/storage.js
+++ b/app/src/services/storage.js
@@ -487,13 +487,13 @@ const objectStorageService = {
    * @function putObjectPublic
    * Puts the public/private status for an object
    * @param {string} options.filePath The filePath of the object
-   * @param {boolean=false} [options.publicFlag] Optional boolean on whether to make the object public
+   * @param {boolean=false} [options.public] Optional boolean on whether to make the object public
    * @param {string} [options.s3VersionId] Optional version ID used to reference a speciific version of the object
    * @param {string} [options.bucketId] Optional bucketId
    * @returns {Promise<PutObjectAclOutput>} The response of the put object acl operation
    * @throws If object is not found
    */
-  async putObjectPublic({ filePath, publicFlag = false, s3VersionId = undefined, bucketId = undefined }) {
+  async putObjectPublic({ filePath, public: publicFlag = false, s3VersionId = undefined, bucketId = undefined }) {
     const acl = publicFlag ? 'public-read' : 'private';
     return this.putObjectAcl({ acl, filePath, s3VersionId, bucketId });
   },

--- a/app/tests/unit/controllers/object.spec.js
+++ b/app/tests/unit/controllers/object.spec.js
@@ -41,6 +41,7 @@ describe('addMetadata', () => {
   const metadataAssociateMetadataSpy = jest.spyOn(metadataService, 'associateMetadata');
   const tagAssociateTagsSpy = jest.spyOn(tagService, 'associateTags');
   const trxWrapperSpy = jest.spyOn(utils, 'trxWrapper');
+  const updateSpy = jest.spyOn(objectService, 'update');
   const setHeadersSpy = jest.spyOn(controller, '_processS3Headers');
 
   const next = jest.fn();
@@ -80,6 +81,7 @@ describe('addMetadata', () => {
     storageGetObjectTaggingSpy.mockResolvedValue({ TagSet: [] });
     storageCopyObjectSpy.mockResolvedValue(GoodResponse);
     trxWrapperSpy.mockImplementation(callback => callback({}));
+    updateSpy.mockResolvedValue({});
     versionCopySpy.mockResolvedValue({ id: '5dad1ec9-d3c0-4b0f-8ead-cb4d9fa98987' });
     metadataAssociateMetadataSpy.mockResolvedValue({});
     setHeadersSpy.mockImplementation(x => x);
@@ -102,6 +104,8 @@ describe('addMetadata', () => {
     });
 
     expect(trxWrapperSpy).toHaveBeenCalledTimes(1);
+    expect(updateSpy).toHaveBeenCalledTimes(1);
+    expect(updateSpy).toHaveBeenCalledWith(expect.objectContaining({ public: false }));
     expect(versionCopySpy).toHaveBeenCalledTimes(1);
     expect(metadataAssociateMetadataSpy).toHaveBeenCalledTimes(1);
     expect(tagAssociateTagsSpy).toHaveBeenCalledTimes(1);
@@ -507,6 +511,11 @@ describe('replaceMetadata', () => {
   const storageGetObjectTaggingSpy = jest.spyOn(storageService, 'getObjectTagging');
   const storageHeadObjectSpy = jest.spyOn(storageService, 'headObject');
   const storageCopyObjectSpy = jest.spyOn(storageService, 'copyObject');
+  const trxWrapperSpy = jest.spyOn(utils, 'trxWrapper');
+  const updateSpy = jest.spyOn(objectService, 'update');
+  const versionCopySpy = jest.spyOn(versionService, 'copy');
+  const metadataAssociateMetadataSpy = jest.spyOn(metadataService, 'associateMetadata');
+  const tagAssociateTagsSpy = jest.spyOn(tagService, 'associateTags');
 
   const next = jest.fn();
 
@@ -539,7 +548,11 @@ describe('replaceMetadata', () => {
 
     storageHeadObjectSpy.mockReturnValue(GoodResponse);
     storageGetObjectTaggingSpy.mockResolvedValue({ TagSet: [] });
-    storageCopyObjectSpy.mockReturnValue({});
+    storageCopyObjectSpy.mockResolvedValue({ VersionId: 'versionId' });
+    trxWrapperSpy.mockImplementation(callback => callback({}));
+    updateSpy.mockResolvedValue({});
+    versionCopySpy.mockResolvedValue({ id: '5dad1ec9-d3c0-4b0f-8ead-cb4d9fa98987' });
+    metadataAssociateMetadataSpy.mockResolvedValue({});
 
     await controller.replaceMetadata(req, res, next);
 
@@ -554,6 +567,14 @@ describe('replaceMetadata', () => {
       tags: { 'coms-id': 'xyz-789' },
       s3VersionId: undefined
     });
+
+    expect(trxWrapperSpy).toHaveBeenCalledTimes(1);
+    expect(updateSpy).toHaveBeenCalledTimes(1);
+    expect(updateSpy).toHaveBeenCalledWith(expect.objectContaining({ public: false }));
+    expect(versionCopySpy).toHaveBeenCalledTimes(1);
+    expect(metadataAssociateMetadataSpy).toHaveBeenCalledTimes(1);
+    expect(tagAssociateTagsSpy).toHaveBeenCalledTimes(1);
+    expect(res.status).toHaveBeenCalledWith(204);
   });
 
   it('should replace replace the name', async () => {

--- a/app/tests/unit/services/storage.spec.js
+++ b/app/tests/unit/services/storage.spec.js
@@ -4,12 +4,14 @@ const {
   DeleteObjectTaggingCommand,
   GetBucketEncryptionCommand,
   GetBucketVersioningCommand,
+  GetObjectAclCommand,
   GetObjectCommand,
   GetObjectTaggingCommand,
   HeadBucketCommand,
   HeadObjectCommand,
   ListObjectsV2Command,
   ListObjectVersionsCommand,
+  PutObjectAclCommand,
   PutBucketEncryptionCommand,
   PutObjectCommand,
   PutObjectTaggingCommand,
@@ -338,6 +340,41 @@ describe('getBucketVersioning', () => {
     expect(s3ClientMock).toHaveReceivedCommandTimes(GetBucketVersioningCommand, 1);
     expect(s3ClientMock).toHaveReceivedCommandWith(GetBucketVersioningCommand, {
       Bucket: bucket
+    });
+  });
+});
+
+describe('getObjectAcl', () => {
+  beforeEach(() => {
+    s3ClientMock.on(GetObjectAclCommand).resolves({});
+  });
+
+  it('should send a get object acl command', async () => {
+    const filePath = 'filePath';
+    const result = await service.getObjectAcl({ filePath });
+
+    expect(result).toBeTruthy();
+    expect(utils.getBucket).toHaveBeenCalledTimes(1);
+    expect(s3ClientMock).toHaveReceivedCommandTimes(GetObjectAclCommand, 1);
+    expect(s3ClientMock).toHaveReceivedCommandWith(GetObjectAclCommand, {
+      Bucket: bucket,
+      Key: filePath,
+      VersionId: undefined
+    });
+  });
+
+  it('should send a put object acl command for a specific version', async () => {
+    const filePath = 'filePath';
+    const s3VersionId = '1234';
+    const result = await service.getObjectAcl({ filePath, s3VersionId });
+
+    expect(result).toBeTruthy();
+    expect(utils.getBucket).toHaveBeenCalledTimes(1);
+    expect(s3ClientMock).toHaveReceivedCommandTimes(GetObjectAclCommand, 1);
+    expect(s3ClientMock).toHaveReceivedCommandWith(GetObjectAclCommand, {
+      Bucket: bucket,
+      Key: filePath,
+      VersionId: s3VersionId
     });
   });
 });
@@ -892,6 +929,45 @@ describe('putObject', () => {
       Key: keyPath,
       Body: stream,
       Tagging: 'foo=foo&bar=bar'
+    });
+  });
+});
+
+describe('putObjectAcl', () => {
+  beforeEach(() => {
+    s3ClientMock.on(PutObjectAclCommand).resolves({});
+  });
+
+  it('should send a put object acl command', async () => {
+    const acl = 'public-read';
+    const filePath = 'filePath';
+    const result = await service.putObjectAcl({ acl, filePath });
+
+    expect(result).toBeTruthy();
+    expect(utils.getBucket).toHaveBeenCalledTimes(1);
+    expect(s3ClientMock).toHaveReceivedCommandTimes(PutObjectAclCommand, 1);
+    expect(s3ClientMock).toHaveReceivedCommandWith(PutObjectAclCommand, {
+      ACL: acl,
+      Bucket: bucket,
+      Key: filePath,
+      VersionId: undefined
+    });
+  });
+
+  it('should send a put object acl for a specific version', async () => {
+    const acl = 'public-read';
+    const filePath = 'filePath';
+    const s3VersionId = '1234';
+    const result = await service.putObjectAcl({ acl, filePath, s3VersionId });
+
+    expect(result).toBeTruthy();
+    expect(utils.getBucket).toHaveBeenCalledTimes(1);
+    expect(s3ClientMock).toHaveReceivedCommandTimes(PutObjectAclCommand, 1);
+    expect(s3ClientMock).toHaveReceivedCommandWith(PutObjectAclCommand, {
+      ACL: acl,
+      Bucket: bucket,
+      Key: filePath,
+      VersionId: s3VersionId
     });
   });
 });


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

<!-- Describe your changes in detail -->
This PR introduces support for modifying the public/private status of an S3 object through S3 ACL permission management. This change will now have the togglePublic endpoint also modify the S3 ACL in addition to the local database. Operations that will implicitly or explicitly generate a new version of an object will now force the object to be toggled to private by default. Finally, synchronization operations will do a best-attempt effort to respect whatever the S3 ACL reports for the object. In the event there is an S3 ACL failure, it will fallback to whatever was defined in the COMS database instead.

- eae9c9c Ensure syncObject factors in S3 ACL public flag status
- 5d7e8f4 Ensure addMetadata, replaceMetadata and updateObject set public as false
- d063de8 Implement graceful S3 ACL propagation to togglePublic endpoint
- 6eb28c4 Add getObjectPublic and putObjectPublic utility functions
- 29b783c Add support for GetObjectAclCommand and PutObjectAclCommand

Note that not all S3-compatible providers support S3 ACL. While Dell ECS and AWS support the `GetObjectAclCommand` and `PutObjectAclCommand`, Minio is known to only support `GetObjectAclCommand`, with `PutObjectAclCommand` deliberately not implemented.

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
[SHOWCASE-3396](https://apps.nrs.gov.bc.ca/int/jira/browse/SHOWCASE-3396)

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
Documentation (non-breaking change with enhancements to documentation)
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->