### PR TITLE
Modify getObject CORP header to use cross-origin policy

### DIFF
--- a/app/src/routes/v1/object.js
+++ b/app/src/routes/v1/object.js
@@ -1,4 +1,5 @@
 const router = require('express').Router();
+const helmet = require('helmet');
 
 const { Permissions } = require('../../components/constants');
 const { objectController, syncController } = require('../../controllers');
@@ -37,7 +38,8 @@ router.head('/:objectId', objectValidator.headObject, currentObject, hasPermissi
 );
 
 /** Returns the object */
-router.get('/:objectId', objectValidator.readObject, currentObject, hasPermission(Permissions.READ),
+router.get('/:objectId', helmet({ crossOriginResourcePolicy: { policy: 'cross-origin' } }),
+  objectValidator.readObject, currentObject, hasPermission(Permissions.READ),
   (req, res, next) => {
   // TODO: Add validation to reject unexpected query parameters
     objectController.readObject(req, res, next);


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

<!-- Describe your changes in detail -->
There are use cases where COMS is being used as a way to directly reference and embed content into a 3rd-party webpage. The default helmet CORP policy of same-origin was too restrictive for this specific endpoint.
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
[https://apps.nrs.gov.bc.ca/int/jira/browse/SHOWCASE-3509](https://apps.nrs.gov.bc.ca/int/jira/browse/SHOWCASE-3509)

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->