### PR TITLE
Make object search filters on version attributes work when combined (intersect)

### DIFF
--- a/app/src/db/models/tables/objectModel.js
+++ b/app/src/db/models/tables/objectModel.js
@@ -78,6 +78,29 @@ class ObjectModel extends Timestamps(Model) {
       filterActive(query, value) {
         if (value !== undefined) query.where('object.active', value);
       },
+      filterVersionAttributes(query, mimeType, deleteMarker, isLatest) {
+        query.modify(query => {
+          query
+            .withGraphJoined('version')
+            .leftJoinRelated('version')
+            .whereIn('version.id', query => {
+              query.select('version.id')
+                .modify(query => {
+                  if (mimeType) {
+                    query.where('version.mimeType', 'ilike', `%${mimeType}%`);
+                  }
+                  if (deleteMarker !== undefined) {
+                    query.where('version.deleteMarker', deleteMarker);
+                  }
+                  if (isLatest !== undefined) {
+                    query.where('version.isLatest', isLatest);
+                  }
+                });
+            });
+          return query;
+        });
+
+      },
       filterMimeType(query, value) {
         if (value) {
           query

--- a/app/src/db/models/tables/objectModel.js
+++ b/app/src/db/models/tables/objectModel.js
@@ -79,68 +79,20 @@ class ObjectModel extends Timestamps(Model) {
         if (value !== undefined) query.where('object.active', value);
       },
       filterVersionAttributes(query, mimeType, deleteMarker, isLatest) {
-        query.modify(query => {
-          query
-            .withGraphJoined('version')
-            .leftJoinRelated('version')
-            .whereIn('version.id', query => {
-              query.select('version.id')
-                .modify(query => {
-                  if (mimeType) {
-                    query.where('version.mimeType', 'ilike', `%${mimeType}%`);
-                  }
-                  if (deleteMarker !== undefined) {
-                    query.where('version.deleteMarker', deleteMarker);
-                  }
-                  if (isLatest !== undefined) {
-                    query.where('version.isLatest', isLatest);
-                  }
-                });
-            });
-          return query;
-        });
-
-      },
-      filterMimeType(query, value) {
-        if (value) {
-          query
-            .withGraphJoined('version')
-            .leftJoinRelated('version')
-            .whereIn('version.id', builder => {
-              builder.select('version.id')
-                .where('version.mimeType', 'ilike', `%${value}%`);
-            });
-        }
-      },
-      filterDeleteMarker(query, value) {
-        if (value !== undefined) {
-          query
-            .withGraphJoined('version')
-            .leftJoinRelated('version')
-            .where('version.deleteMarker', value);
-        }
-      },
-      filterLatest(query, value) {
-        if (value !== undefined) {
-
-          query.withGraphJoined('version');
-          if (value) {
-            // join on version where isLatest = true
-            query.modifyGraph('version', builder => {
-              builder
-                .select('version.*')
-                .where('version.isLatest', true);
-            });
-          } else {
-            // join on ALL versions where isLatest = false
-            const subquery = Version.query()
-              .select('version.id')
-              .where('version.isLatest', false);
-            query.whereIn('version.id', builder => {
-              builder.intersect(subquery);
-            });
-          }
-        }
+        query
+          .withGraphJoined('version')
+          .leftJoinRelated('version')
+          .modify(query => {
+            if (mimeType) {
+              query.where('version.mimeType', 'ilike', `%${mimeType}%`);
+            }
+            if (deleteMarker !== undefined) {
+              query.where('version.deleteMarker', deleteMarker);
+            }
+            if (isLatest !== undefined) {
+              query.where('version.isLatest', isLatest);
+            }
+          });
       },
       filterMetadataTag(query, value) {
         const subqueries = [];

--- a/app/src/services/object.js
+++ b/app/src/services/object.js
@@ -130,20 +130,27 @@ const service = {
       response.data = await ObjectModel.query(trx)
         .allowGraph('[bucketPermission, objectPermission, version]')
         .groupBy('object.id')
+        // object
         .modify('filterIds', params.id)
         .modify('filterBucketIds', params.bucketId)
         .modify('filterName', params.name)
         .modify('filterPath', params.path)
         .modify('filterPublic', params.public)
         .modify('filterActive', params.active)
+        // version
         .modify('filterVersionAttributes', params.mimeType, params.deleteMarker, params.latest)
+        // meta/tag
         .modify('filterMetadataTag', {
           metadata: params.metadata,
           tag: params.tag
         })
+        // permissions
         .modify('hasPermission', params.userId, 'READ')
+        // pagination
         .modify('pagination', params.page, params.limit)
+        // sort results
         .modify('sortOrder', params.sort, params.order)
+        // format response
         .then(result => {
           let results = [];
           if (Object.hasOwn(result, 'results')) {

--- a/app/src/services/object.js
+++ b/app/src/services/object.js
@@ -136,9 +136,7 @@ const service = {
         .modify('filterPath', params.path)
         .modify('filterPublic', params.public)
         .modify('filterActive', params.active)
-        .modify('filterMimeType', params.mimeType)
-        .modify('filterDeleteMarker', params.deleteMarker)
-        .modify('filterLatest', params.latest)
+        .modify('filterVersionAttributes', params.mimeType, params.deleteMarker, params.latest)
         .modify('filterMetadataTag', {
           metadata: params.metadata,
           tag: params.tag

--- a/app/tests/unit/services/object.spec.js
+++ b/app/tests/unit/services/object.spec.js
@@ -108,15 +108,14 @@ describe('searchObjects', () => {
   it('Search and filter for specific object records with permissions and without pagination', async () => {
     const params = {
       bucketId: BUCKET_ID,
-      bucketName: 'bucketName',
       active: 'true',
       key: 'key',
       userId: 'ae8a58f6-62bc-4dd1-acef-79f123609d48',
-      permissions: true
+      permissions: true,
     };
 
     // We only care about mocking the final 13th chained modify result
-    for (let i = 0; i < 12; i++) ObjectModel.modify.mockReturnValueOnce(ObjectModel);
+    for (let i = 0; i < 10; i++) ObjectModel.modify.mockReturnValueOnce(ObjectModel);
     ObjectModel.modify.mockResolvedValueOnce([{
       objectPermission: [{ permCode: 'READ' }], ...params
     }]);
@@ -136,34 +135,33 @@ describe('searchObjects', () => {
     expect(ObjectModel.allowGraph).toHaveBeenCalledTimes(1);
     expect(ObjectModel.allowGraph).toHaveBeenCalledWith('[bucketPermission, objectPermission, version]');
     expect(ObjectModel.groupBy).toHaveBeenCalledTimes(1);
-    expect(ObjectModel.modify).toHaveBeenCalledTimes(13);
+    expect(ObjectModel.modify).toHaveBeenCalledTimes(11);
     expect(ObjectModel.modify).toHaveBeenNthCalledWith(1, 'filterIds', params.id);
     expect(ObjectModel.modify).toHaveBeenNthCalledWith(2, 'filterBucketIds', params.bucketId);
     expect(ObjectModel.modify).toHaveBeenNthCalledWith(3, 'filterName', params.name);
     expect(ObjectModel.modify).toHaveBeenNthCalledWith(4, 'filterPath', params.path);
     expect(ObjectModel.modify).toHaveBeenNthCalledWith(5, 'filterPublic', params.public);
     expect(ObjectModel.modify).toHaveBeenNthCalledWith(6, 'filterActive', params.active);
-    expect(ObjectModel.modify).toHaveBeenNthCalledWith(7, 'filterMimeType', params.mimeType);
-    expect(ObjectModel.modify).toHaveBeenNthCalledWith(8, 'filterDeleteMarker', params.deleteMarker);
-    expect(ObjectModel.modify).toHaveBeenNthCalledWith(9, 'filterLatest', params.latest);
-    expect(ObjectModel.modify).toHaveBeenNthCalledWith(10, 'filterMetadataTag', {
+    expect(ObjectModel.modify).toHaveBeenNthCalledWith(
+      7, 'filterVersionAttributes', params.mimeType, params.deleteMarker, params.latest
+    );
+    expect(ObjectModel.modify).toHaveBeenNthCalledWith(8, 'filterMetadataTag', {
       metadata: params.metadata,
       tag: params.tag
     });
-    expect(ObjectModel.modify).toHaveBeenNthCalledWith(11, 'hasPermission', params.userId, 'READ');
-    expect(ObjectModel.modify).toHaveBeenNthCalledWith(12, 'pagination', params.page, params.limit);
-    expect(ObjectModel.modify).toHaveBeenNthCalledWith(13, 'sortOrder', params.sort, params.order);
+    expect(ObjectModel.modify).toHaveBeenNthCalledWith(9, 'hasPermission', params.userId, 'READ');
+    expect(ObjectModel.modify).toHaveBeenNthCalledWith(10, 'pagination', params.page, params.limit);
+    expect(ObjectModel.modify).toHaveBeenNthCalledWith(11, 'sortOrder', params.sort, params.order);
     expect(objectModelTrx.commit).toHaveBeenCalledTimes(1);
   });
 
   it('Search and filter for specific object records with pagination', async () => {
     // We only care about mocking the final 13th chained modify result
-    for (let i = 0; i < 12; i++) ObjectModel.modify.mockReturnValueOnce(ObjectModel);
+    for (let i = 0; i < 10; i++) ObjectModel.modify.mockReturnValueOnce(ObjectModel);
     ObjectModel.modify.mockResolvedValueOnce({ total: 0, results: [] });
 
     const params = {
       bucketId: BUCKET_ID,
-      bucketName: 'bucketName',
       active: 'true',
       key: 'key',
       userId: SYSTEM_USER,
@@ -183,23 +181,23 @@ describe('searchObjects', () => {
     expect(ObjectModel.allowGraph).toHaveBeenCalledTimes(1);
     expect(ObjectModel.allowGraph).toHaveBeenCalledWith('[bucketPermission, objectPermission, version]');
     expect(ObjectModel.groupBy).toHaveBeenCalledTimes(1);
-    expect(ObjectModel.modify).toHaveBeenCalledTimes(13);
+    expect(ObjectModel.modify).toHaveBeenCalledTimes(11);
     expect(ObjectModel.modify).toHaveBeenNthCalledWith(1, 'filterIds', params.id);
     expect(ObjectModel.modify).toHaveBeenNthCalledWith(2, 'filterBucketIds', params.bucketId);
     expect(ObjectModel.modify).toHaveBeenNthCalledWith(3, 'filterName', params.name);
     expect(ObjectModel.modify).toHaveBeenNthCalledWith(4, 'filterPath', params.path);
     expect(ObjectModel.modify).toHaveBeenNthCalledWith(5, 'filterPublic', params.public);
     expect(ObjectModel.modify).toHaveBeenNthCalledWith(6, 'filterActive', params.active);
-    expect(ObjectModel.modify).toHaveBeenNthCalledWith(7, 'filterMimeType', params.mimeType);
-    expect(ObjectModel.modify).toHaveBeenNthCalledWith(8, 'filterDeleteMarker', params.deleteMarker);
-    expect(ObjectModel.modify).toHaveBeenNthCalledWith(9, 'filterLatest', params.latest);
-    expect(ObjectModel.modify).toHaveBeenNthCalledWith(10, 'filterMetadataTag', {
+    expect(ObjectModel.modify).toHaveBeenNthCalledWith(
+      7, 'filterVersionAttributes', params.mimeType, params.deleteMarker, params.latest
+    );
+    expect(ObjectModel.modify).toHaveBeenNthCalledWith(8, 'filterMetadataTag', {
       metadata: params.metadata,
       tag: params.tag
     });
-    expect(ObjectModel.modify).toHaveBeenNthCalledWith(11, 'hasPermission', params.userId, 'READ');
-    expect(ObjectModel.modify).toHaveBeenNthCalledWith(12, 'pagination', params.page, params.limit);
-    expect(ObjectModel.modify).toHaveBeenNthCalledWith(13, 'sortOrder', params.sort, params.order);
+    expect(ObjectModel.modify).toHaveBeenNthCalledWith(9, 'hasPermission', params.userId, 'READ');
+    expect(ObjectModel.modify).toHaveBeenNthCalledWith(10, 'pagination', params.page, params.limit);
+    expect(ObjectModel.modify).toHaveBeenNthCalledWith(11, 'sortOrder', params.sort, params.order);
     expect(objectModelTrx.commit).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
ticket: https://apps.nrs.gov.bc.ca/int/jira/browse/SHOWCASE-3511

Modifier used by searchObjecs service, to ensure filters for version attributes `isLatest`, `deleted` and `mimetype` work together.

<!-- Provide a general summary of your changes in the Title above -->
# Description

Ticket: https://apps.nrs.gov.bc.ca/int/jira/browse/SHOWCASE-3511

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [ ] I have checked that unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->