### PR TITLE
Bugfix: correctly read node-config environment variables explicitly set to false

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -10,7 +10,7 @@ const { AuthMode, DEFAULTCORS } = require('./src/components/constants');
 const log = require('./src/components/log')(module.filename);
 const httpLogger = require('./src/components/log').httpLogger;
 const QueueManager = require('./src/components/queueManager');
-const { getAppAuthMode, getGitRevision } = require('./src/components/utils');
+const { getAppAuthMode, getConfigBoolean, getGitRevision } = require('./src/components/utils');
 const DataConnection = require('./src/db/dataConnection');
 const v1Router = require('./src/routes/v1');
 const { readUnique } = require('./src/services/bucket');
@@ -67,7 +67,7 @@ if (state.authMode === AuthMode.OIDCAUTH || state.authMode === AuthMode.FULLAUTH
 }
 
 // Application privacy Mode mode
-if (config.has('server.privacyMask')) {
+if (getConfigBoolean('server.privacyMask')) {
   log.info('Running COMS with strict content privacy masking');
 } else {
   log.info('Running COMS with permissive content privacy masking');
@@ -95,7 +95,7 @@ apiRouter.get('/', (_req, res) => {
         gitRev: state.gitRev,
         name: appName,
         nodeVersion: process.version,
-        privacyMask: config.has('server.privacyMask'),
+        privacyMask: getConfigBoolean('server.privacyMask'),
         version: appVersion
       },
       endpoints: ['/api/v1'],
@@ -204,7 +204,7 @@ function initializeConnections() {
       if (state.connections.data) {
         log.info('DataConnection Reachable', { function: 'initializeConnections' });
       }
-      if (config.has('objectStorage.enabled')) {
+      if (getConfigBoolean('objectStorage.enabled')) {
         readUnique(config.get('objectStorage')).then(() => {
           log.error('Default bucket cannot also exist in database', { function: 'initializeConnections' });
           fatalErrorHandler();

--- a/app/src/components/utils.js
+++ b/app/src/components/utils.js
@@ -133,7 +133,9 @@ const utils = {
    */
   getConfigBoolean(key) {
     try {
-      return utils.isTruthy(config.get(key));
+      const getConfig = config.get(key);
+      if (getConfig === undefined || getConfig === null) return false;
+      else return utils.isTruthy(getConfig);
     }
     catch {
       return false;

--- a/app/src/components/utils.js
+++ b/app/src/components/utils.js
@@ -134,6 +134,9 @@ const utils = {
   getConfigBoolean(key) {
     try {
       const getConfig = config.get(key);
+
+      // isTruthy() can't handle undefined / null, so we have to do that here
+      // @see {@link https://github.com/node-config/node-config/wiki/Common-Usage#using-config-values}
       if (getConfig === undefined || getConfig === null) return false;
       else return utils.isTruthy(getConfig);
     }

--- a/app/src/components/utils.js
+++ b/app/src/components/utils.js
@@ -51,8 +51,8 @@ const utils = {
    * @returns {string} The application AuthMode
    */
   getAppAuthMode() {
-    const basicAuth = config.has('basicAuth.enabled');
-    const oidcAuth = config.has('keycloak.enabled');
+    const basicAuth = utils.getConfigBoolean('basicAuth.enabled');
+    const oidcAuth = utils.getConfigBoolean('keycloak.enabled');
 
     if (!basicAuth && !oidcAuth) return AuthMode.NOAUTH;
     else if (basicAuth && !oidcAuth) return AuthMode.BASICAUTH;
@@ -83,7 +83,7 @@ const utils = {
         data.key = bucketData.key;
         data.secretAccessKey = bucketData.secretAccessKey;
         if (bucketData.region) data.region = bucketData.region;
-      } else if (config.has('objectStorage') && config.has('objectStorage.enabled')) {
+      } else if (utils.getConfigBoolean('objectStorage.enabled')) {
         data.accessKeyId = config.get('objectStorage.accessKeyId');
         data.bucket = config.get('objectStorage.bucket');
         data.endpoint = config.get('objectStorage.endpoint');
@@ -120,6 +120,24 @@ const utils = {
       });
     }
     return bucketId;
+  },
+
+  /**
+   * @function getConfigBoolean
+   * Gets the value of a boolean node-config key.
+   * Keys that don't exist in the config are automatically converted to `false`,
+   * thus avoiding the need to either call `config.has()` first, or wrap `config.get()`
+   * inside a try-catch block every time.
+   * @param {string} key the configuration value to look up. Must be either true, false, or not exist in the config.
+   * @returns {boolean} `true` if key exists in config and is true, `false` otherwise
+   */
+  getConfigBoolean(key) {
+    try {
+      return utils.isTruthy(config.get(key));
+    }
+    catch {
+      return false;
+    }
   },
 
   /**

--- a/app/src/controllers/metadata.js
+++ b/app/src/controllers/metadata.js
@@ -1,6 +1,5 @@
-const config = require('config');
 const errorToProblem = require('../components/errorToProblem');
-const { getMetadata } = require('../components/utils');
+const { getConfigBoolean, getMetadata } = require('../components/utils');
 const { metadataService } = require('../services');
 
 const SERVICE = 'MetadataService';
@@ -22,7 +21,7 @@ const controller = {
       const metadata = getMetadata(req.headers);
       const params = {
         metadata: metadata && Object.keys(metadata).length ? metadata : undefined,
-        privacyMask : req.currentUser.authType !== 'BASIC' ? config.has('server.privacyMask') : false
+        privacyMask: req.currentUser.authType !== 'BASIC' ? getConfigBoolean('server.privacyMask') : false
       };
 
       const response = await metadataService.searchMetadata(params);

--- a/app/src/controllers/object.js
+++ b/app/src/controllers/object.js
@@ -1,5 +1,4 @@
 const Problem = require('api-problem');
-const config = require('config');
 const cors = require('cors');
 const { v4: uuidv4, NIL: SYSTEM_USER } = require('uuid');
 
@@ -16,6 +15,7 @@ const log = require('../components/log')(module.filename);
 const {
   addDashesToUuid,
   getBucketId,
+  getConfigBoolean,
   getCurrentIdentity,
   getKeyValue,
   getMetadata,
@@ -618,7 +618,7 @@ const controller = {
         metadata: metadata && Object.keys(metadata).length ? metadata : undefined
       };
       // if scoping to current user permissions on objects
-      if (config.has('server.privacyMask')) {
+      if (getConfigBoolean('server.privacyMask')) {
         params.userId = await userService.getCurrentUserId(getCurrentIdentity(req.currentUser, SYSTEM_USER));
       }
       const response = await metadataService.fetchMetadataForObject(params);
@@ -647,7 +647,7 @@ const controller = {
         tagset: tagset && Object.keys(tagset).length ? tagset : undefined,
       };
       // if scoping to current user permissions on objects
-      if (config.has('server.privacyMask')) {
+      if (getConfigBoolean('server.privacyMask')) {
         params.userId = await userService.getCurrentUserId(getCurrentIdentity(req.currentUser, SYSTEM_USER));
       }
       const response = await tagService.fetchTagsForObject(params);
@@ -943,7 +943,7 @@ const controller = {
         order: req.query.order,
       };
       // if scoping to current user permissions on objects
-      if (config.has('server.privacyMask')) {
+      if (getConfigBoolean('server.privacyMask')) {
         params.userId = await userService.getCurrentUserId(getCurrentIdentity(req.currentUser, SYSTEM_USER));
       }
       const response = await objectService.searchObjects(params);

--- a/app/src/controllers/tag.js
+++ b/app/src/controllers/tag.js
@@ -1,6 +1,6 @@
-const config = require('config');
 const errorToProblem = require('../components/errorToProblem');
 const { tagService } = require('../services');
+const { getConfigBoolean } = require('../components/utils');
 
 const SERVICE = 'TagService';
 
@@ -22,7 +22,7 @@ const controller = {
       const tagging = req.query.tagset;
       const params = {
         tag: tagging && Object.keys(tagging).length ? tagging : undefined,
-        privacyMask : req.currentUser.authType !== 'BASIC' ? config.has('server.privacyMask') : false
+        privacyMask: req.currentUser.authType !== 'BASIC' ? getConfigBoolean('server.privacyMask') : false
       };
 
       const response = await tagService.searchTags(params);

--- a/app/src/controllers/version.js
+++ b/app/src/controllers/version.js
@@ -1,7 +1,12 @@
-const config = require('config');
 const { NIL: SYSTEM_USER } = require('uuid');
 const errorToProblem = require('../components/errorToProblem');
-const { addDashesToUuid, getCurrentIdentity, getMetadata, mixedQueryToArray } = require('../components/utils');
+const {
+  getConfigBoolean,
+  getCurrentIdentity,
+  addDashesToUuid,
+  getMetadata,
+  mixedQueryToArray
+} = require('../components/utils');
 const { metadataService, tagService, userService } = require('../services');
 
 const SERVICE = 'VersionService';
@@ -30,7 +35,7 @@ const controller = {
         metadata: metadata && Object.keys(metadata).length ? metadata : undefined,
       };
       // if scoping to current user permissions on objects
-      if (config.has('server.privacyMask')) {
+      if (getConfigBoolean('server.privacyMask')) {
         params.userId = await userService.getCurrentUserId(getCurrentIdentity(req.currentUser, SYSTEM_USER));
       }
       const response = await metadataService.fetchMetadataForVersion(params);
@@ -60,7 +65,7 @@ const controller = {
         tags: tagging && Object.keys(tagging).length ? tagging : undefined,
       };
       // if scoping to current user permissions on objects
-      if (config.has('server.privacyMask')) {
+      if (getConfigBoolean('server.privacyMask')) {
         params.userId = await userService.getCurrentUserId(getCurrentIdentity(req.currentUser, SYSTEM_USER));
       }
       const response = await tagService.fetchTagsForVersion(params);

--- a/app/src/middleware/authentication.js
+++ b/app/src/middleware/authentication.js
@@ -4,6 +4,7 @@ const basicAuth = require('express-basic-auth');
 const jwt = require('jsonwebtoken');
 
 const { AuthType } = require('../components/constants');
+const { getConfigBoolean } = require('../components/utils');
 const { userService } = require('../services');
 
 /**
@@ -54,12 +55,12 @@ const currentUser = async (req, res, next) => {
 
   if (authorization) {
     // Basic Authorization
-    if (config.has('basicAuth.enabled') && authorization.toLowerCase().startsWith('basic ')) {
+    if (getConfigBoolean('basicAuth.enabled') && authorization.toLowerCase().startsWith('basic ')) {
       currentUser.authType = AuthType.BASIC;
     }
 
     // OIDC JWT Authorization
-    else if (config.has('keycloak.enabled') && authorization.toLowerCase().startsWith('bearer ')) {
+    else if (getConfigBoolean('keycloak.enabled') && authorization.toLowerCase().startsWith('bearer ')) {
       currentUser.authType = AuthType.BEARER;
 
       try {

--- a/app/src/routes/v1/docs.js
+++ b/app/src/routes/v1/docs.js
@@ -4,13 +4,14 @@ const { readFileSync } = require('fs');
 const helmet = require('helmet');
 const yaml = require('js-yaml');
 const { join } = require('path');
+const { getConfigBoolean } = require('../../components/utils');
 
 /** Gets the OpenAPI specification */
 function getSpec() {
   const rawSpec = readFileSync(join(__dirname, '../../docs/v1.api-spec.yaml'), 'utf8');
   const spec = yaml.load(rawSpec);
   spec.servers[0].url = '/api/v1';
-  if (config.has('keycloak.enabled')) {
+  if (getConfigBoolean('keycloak.enabled')) {
     // eslint-disable-next-line max-len
     spec.components.securitySchemes.OpenID.openIdConnectUrl = `${config.get('keycloak.serverUrl')}/realms/${config.get('keycloak.realm')}/.well-known/openid-configuration`;
   }

--- a/app/tests/unit/components/utils.spec.js
+++ b/app/tests/unit/components/utils.spec.js
@@ -174,6 +174,24 @@ describe('getBucket', () => {
   });
 });
 
+describe('getConfigBoolean', () => {
+  it.each([
+    [true, true],
+    [false, false],
+    [false, null],
+    [false, undefined],
+    [false, Error()],
+  ])('should return %s when config.get() returns %s', (expected, getConfigOutput) => {
+
+    config.get.mockReturnValueOnce(getConfigOutput);
+    utils.isTruthy.mockReturnValueOnce(getConfigOutput);
+
+    const output = utils.getConfigBoolean('some.key');
+
+    expect(output).toEqual(expected);
+  });
+});
+
 describe('getCurrentIdentity', () => {
   const getCurrentTokenClaimSpy = jest.spyOn(utils, 'getCurrentTokenClaim');
   const parseIdentityKeyClaimsSpy = jest.spyOn(utils, 'parseIdentityKeyClaims');

--- a/app/tests/unit/components/utils.spec.js
+++ b/app/tests/unit/components/utils.spec.js
@@ -78,13 +78,14 @@ describe('delimit', () => {
 });
 
 describe('getAppAuthMode', () => {
+  const getConfigBooleanSpy = jest.spyOn(utils, 'getConfigBoolean');
   it.each([
     [AuthMode.NOAUTH, false, false],
     [AuthMode.BASICAUTH, true, false],
     [AuthMode.OIDCAUTH, false, true],
     [AuthMode.FULLAUTH, true, true]
   ])('should return %s when basicAuth.enabled %s and keycloak.enabled %s', (expected, basicAuth, keycloak) => {
-    utils.getConfigBoolean
+    getConfigBooleanSpy
       .mockReturnValueOnce(basicAuth) // basicAuth.enabled
       .mockReturnValueOnce(keycloak); // keycloak.enabled
 
@@ -175,16 +176,22 @@ describe('getBucket', () => {
 });
 
 describe('getConfigBoolean', () => {
+  const getConfigBooleanSpy = jest.spyOn(utils, 'getConfigBoolean');
+  const isTruthySpy = jest.spyOn(utils, 'isTruthy');
+
   it.each([
     [true, true],
     [false, false],
     [false, null],
-    [false, undefined],
-    [false, Error()],
+    [false, undefined]
+    // [false, new Error('key does not exist!')],
   ])('should return %s when config.get() returns %s', (expected, getConfigOutput) => {
 
-    config.get.mockReturnValueOnce(getConfigOutput);
-    utils.isTruthy.mockReturnValueOnce(getConfigOutput);
+    // if (getConfigOutput instanceof Error)
+    //   getConfigBooleanSpy.mockRejectedValue(getConfigOutput);
+    // else
+    getConfigBooleanSpy.mockReturnValueOnce(getConfigOutput);
+    isTruthySpy.mockReturnValueOnce(getConfigOutput);
 
     const output = utils.getConfigBoolean('some.key');
 
@@ -435,6 +442,9 @@ describe('isAtPath', () => {
 });
 
 describe('isTruthy', () => {
+
+  utils.isTruthy.mockRestore();
+
   it('should return undefined given undefined', () => {
     expect(utils.isTruthy(undefined)).toBeUndefined();
   });

--- a/app/tests/unit/components/utils.spec.js
+++ b/app/tests/unit/components/utils.spec.js
@@ -185,14 +185,15 @@ describe('getConfigBoolean', () => {
     [true, true],
     [false, false],
     [false, null],
-    [false, undefined]
-    // [false, new Error('key does not exist!')],
+    [false, undefined],
+    [false, 'exception']
   ])('should return %s when config.get() returns %s', (expected, getConfigOutput) => {
 
-    // if (getConfigOutput instanceof Error)
-    //   getConfigBooleanSpy.mockRejectedValue(getConfigOutput);
-    // else
-    config.get.mockReturnValueOnce(getConfigOutput);
+    // config.get() throws exception if the requested key doesn't exist
+    if (getConfigOutput === 'exception')
+      config.get.mockImplementation(() => { throw Error('key does not exist!'); });
+    else
+      config.get.mockReturnValueOnce(getConfigOutput);
     isTruthySpy.mockReturnValueOnce(getConfigOutput);
 
     const output = utils.getConfigBoolean('some.key');

--- a/app/tests/unit/components/utils.spec.js
+++ b/app/tests/unit/components/utils.spec.js
@@ -176,7 +176,9 @@ describe('getBucket', () => {
 });
 
 describe('getConfigBoolean', () => {
-  const getConfigBooleanSpy = jest.spyOn(utils, 'getConfigBoolean');
+  beforeAll(() => {
+    utils.getConfigBoolean.mockRestore();
+  });
   const isTruthySpy = jest.spyOn(utils, 'isTruthy');
 
   it.each([
@@ -190,7 +192,7 @@ describe('getConfigBoolean', () => {
     // if (getConfigOutput instanceof Error)
     //   getConfigBooleanSpy.mockRejectedValue(getConfigOutput);
     // else
-    getConfigBooleanSpy.mockReturnValueOnce(getConfigOutput);
+    config.get.mockReturnValueOnce(getConfigOutput);
     isTruthySpy.mockReturnValueOnce(getConfigOutput);
 
     const output = utils.getConfigBoolean('some.key');
@@ -443,7 +445,9 @@ describe('isAtPath', () => {
 
 describe('isTruthy', () => {
 
-  utils.isTruthy.mockRestore();
+  beforeAll(() => {
+    utils.isTruthy.mockRestore();
+  });
 
   it('should return undefined given undefined', () => {
     expect(utils.isTruthy(undefined)).toBeUndefined();

--- a/app/tests/unit/components/utils.spec.js
+++ b/app/tests/unit/components/utils.spec.js
@@ -84,14 +84,14 @@ describe('getAppAuthMode', () => {
     [AuthMode.OIDCAUTH, false, true],
     [AuthMode.FULLAUTH, true, true]
   ])('should return %s when basicAuth.enabled %s and keycloak.enabled %s', (expected, basicAuth, keycloak) => {
-    config.has
+    utils.getConfigBoolean
       .mockReturnValueOnce(basicAuth) // basicAuth.enabled
       .mockReturnValueOnce(keycloak); // keycloak.enabled
 
     const result = utils.getAppAuthMode();
 
     expect(result).toEqual(expected);
-    expect(config.has).toHaveBeenCalledTimes(2);
+    expect(utils.getConfigBoolean).toHaveBeenCalledTimes(2);
   });
 });
 
@@ -113,9 +113,10 @@ describe('getBucket', () => {
     secretAccessKey: 'soo'
   };
   const readBucketSpy = jest.spyOn(bucketService, 'read');
+  const getConfigBooleanSpy = jest.spyOn(utils, 'getConfigBoolean');
 
   it('should return config data when it exists, given no bucketId', async () => {
-    config.has.mockReturnValue(true);
+    getConfigBooleanSpy.mockReturnValueOnce(true);
     config.get
       .mockReturnValueOnce(cdata.accessKeyId) // objectStorage.accessKeyId
       .mockReturnValueOnce(cdata.bucket) // objectStorage.bucket
@@ -586,11 +587,11 @@ describe('toLowerKeys', () => {
 });
 
 describe('getUniqueObjects', () => {
-  const testObj1 = {key1: 'test1', val1: 'val11', val2: 'val21'};
-  const testObj2 = {key1: 'test2', val1: 'val12', val2: 'val22'};
-  const testObj3 = {key1: 'test3', val1: 'val13', val2: 'val23'};
-  const testObj4 = {key1: 'test4', val1: 'val14', val2: 'val24'};
-  const testObj5 = {key1: 'test4', val1: 'val15', val2: 'val25'};
+  const testObj1 = { key1: 'test1', val1: 'val11', val2: 'val21' };
+  const testObj2 = { key1: 'test2', val1: 'val12', val2: 'val22' };
+  const testObj3 = { key1: 'test3', val1: 'val13', val2: 'val23' };
+  const testObj4 = { key1: 'test4', val1: 'val14', val2: 'val24' };
+  const testObj5 = { key1: 'test4', val1: 'val15', val2: 'val25' };
 
   it('return all input objects', () => {
     expect(utils.getUniqueObjects([

--- a/app/tests/unit/controllers/metadata.spec.js
+++ b/app/tests/unit/controllers/metadata.spec.js
@@ -47,6 +47,7 @@ describe('searchMetadata', () => {
 
     expect(metadataSearchMetadataSpy).toHaveBeenCalledWith({
       metadata: undefined,
+      privacyMask: false
     });
 
     expect(res.json).toHaveBeenCalledWith(GoodResponse);
@@ -71,6 +72,7 @@ describe('searchMetadata', () => {
 
     expect(metadataSearchMetadataSpy).toHaveBeenCalledWith({
       metadata: { foo: '' },
+      privacyMask: false
     });
     expect(res.json).toHaveBeenCalledWith(GoodResponse);
     expect(res.status).toHaveBeenCalledWith(200);

--- a/app/tests/unit/controllers/tag.spec.js
+++ b/app/tests/unit/controllers/tag.spec.js
@@ -49,7 +49,8 @@ describe('searchTags', () => {
     await controller.searchTags(req, res, next);
 
     expect(tagSearchTagsSpy).toHaveBeenCalledWith({
-      tags: undefined,
+      tag: undefined,
+      privacyMask: false
     });
 
     expect(res.json).toHaveBeenCalledWith(GoodResponse);
@@ -79,6 +80,7 @@ describe('searchTags', () => {
 
     expect(tagSearchTagsSpy).toHaveBeenCalledWith({
       tag: { foo: '' },
+      privacyMask: false
     });
     expect(res.json).toHaveBeenCalledWith(GoodResponse);
     expect(res.status).toHaveBeenCalledWith(200);


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

<!-- Describe your changes in detail -->
This PR resolves #86.

Environment variables with a value of `false` are now correctly interpreted as such. Previously, the mere presence of a key would mean that its value would be interpreted as `true`, even if it is explicitly set to `false`.

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
https://apps.nrs.gov.bc.ca/int/jira/browse/SHOWCASE-3115

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
The Jira ticket contains the following suggested implementation:
```js
const foo: boolean = config.has('some.thing') && utils.isTruthy(config.get('some.thing'));
```
This approach was ultimately not used, as the potential short-circuiting of the boolean (i.e. when the config doesn't contain `'some.thing'`) would interefere with Jest mocking since `isTruthy()` won't get called, throwing off the order of the mocks.

Instead, `config.get()` is used, with the potential exception (raised when `'some.thing'` doesn't exist) handled as appropriate.

This implementation is encapsulated in the helper function `utils.getConfigBoolean()` under `/app/src/components/utils.js`.