### PR TITLE
Add new table columns for tracking last sync timestamps

### DIFF
--- a/app/src/db/migrations/20240203003345_012-last-modified-last-synced.js
+++ b/app/src/db/migrations/20240203003345_012-last-modified-last-synced.js
@@ -1,0 +1,32 @@
+exports.up = function (knex) {
+  return Promise.resolve()
+    // Add lastModifiedDate column to version table
+    .then(() => knex.schema.alterTable('version', table => {
+      table.timestamp('lastModifiedDate', { useTz: true });
+    }))
+    // Add lastSyncedDate column to object table
+    .then(() => knex.schema.alterTable('object', table => {
+      table.timestamp('lastSyncedDate', { useTz: true });
+    }))
+    // Add lastSyncRequestedDate to bucket table
+    .then(() => knex.schema.alterTable('bucket', table => {
+      table.timestamp('lastSyncRequestedDate', { useTz: true });
+    }));
+
+};
+
+exports.down = function (knex) {
+  return Promise.resolve()
+    // Drop lastSyncRequestedDate from bucket table
+    .then(() => knex.schema.alterTable('bucket', table => {
+      table.dropColumn('lastSyncRequestedDate');
+    }))
+    // DroplastSyncedDate column from object table
+    .then(() => knex.schema.alterTable('object', table => {
+      table.dropColumn('lastSyncedDate');
+    }))
+    // Drop lastModifiedDate column from version table
+    .then(() => knex.schema.alterTable('version', table => {
+      table.dropColumn('lastModifiedDate');
+    }));
+};

--- a/app/src/db/models/tables/bucket.js
+++ b/app/src/db/models/tables/bucket.js
@@ -88,6 +88,7 @@ class Bucket extends mixin(Model, [
         secretAccessKey: { type: 'string', minLength: 1, maxLength: 255 },
         region: { type: 'string', maxLength: 255 },
         active: { type: 'boolean' },
+        lastSyncRequestedDate: { type: ['string', 'null'] },
         ...stamps
       },
       additionalProperties: false

--- a/app/src/db/models/tables/objectModel.js
+++ b/app/src/db/models/tables/objectModel.js
@@ -181,6 +181,7 @@ class ObjectModel extends Timestamps(Model) {
         active: { type: 'boolean' },
         bucketId: { type: 'string', maxLength: 255, nullable: true },
         name: { type: 'string', maxLength: 1024 },
+        lastSyncedDate: { type: ['string', 'null'] },
         ...stamps
       },
       additionalProperties: false

--- a/app/src/db/models/tables/version.js
+++ b/app/src/db/models/tables/version.js
@@ -90,6 +90,7 @@ class Version extends Timestamps(Model) {
         deleteMarker: { type: 'boolean' },
         etag: { type: 'string', maxLength: 65536 },
         isLatest: { type: 'boolean' },
+        lastModifiedDate: { type: ['string', 'null'] },
         ...stamps
       },
       additionalProperties: false

--- a/app/src/docs/v1.api-spec.yaml
+++ b/app/src/docs/v1.api-spec.yaml
@@ -1936,6 +1936,13 @@ components:
               type: string
               example: coms/env
               maxLength: 255
+            lastSyncRequestedDate:
+              description: >-
+                Time when a sync request was last submitted for the bucket
+              type: string
+              format: date-time
+              example: "2022-03-11T23:19:16.343Z"
+              default: null
             region:
               type: string
               description: >-
@@ -2070,6 +2077,13 @@ components:
               description: An array of explicit permCodes the current user has. Empty array if authenticated via Basic auth or if user lacks explicit permissions for the object. Attribute only appears if request contains permissions query parameter
               example:
                 - READ
+            lastSyncedDate:
+              type: string
+              format: date-time
+              description: >-
+                Time when the object was last synced with the S3 bucket
+              example: "2022-03-11T23:19:16.343Z"
+              default: null
         - $ref: "#/components/schemas/DB-TimestampUserData"
     DB-ObjectPermission:
       title: DB Object Permission
@@ -2245,6 +2259,14 @@ components:
                 An entity tag (ETag) is an opaque identifier assigned by a web
                 server to a specific version of a resource found at a URL
               example: '"9d1aaa54b84e1d6ccc6e0477c5717fe3"'
+            lastModifiedDate:
+              type: string
+              format: date-time
+              description: >-
+                The object creation date or the last modified date (as exposed by S3's
+                `Last-Modified` header), whichever is the latest.
+              example: "2022-03-11T23:19:16.343Z"
+              default: null
         - $ref: "#/components/schemas/DB-TimestampUserData"
     DownloadMode:
       title: Download Mode

--- a/app/src/docs/v1.api-spec.yaml
+++ b/app/src/docs/v1.api-spec.yaml
@@ -2070,13 +2070,6 @@ components:
               type: string
               description: The filename of the original file uploaded
               example: foobar.txt
-            permissions:
-              type: array
-              items:
-                type: string
-              description: An array of explicit permCodes the current user has. Empty array if authenticated via Basic auth or if user lacks explicit permissions for the object. Attribute only appears if request contains permissions query parameter
-              example:
-                - READ
             lastSyncedDate:
               type: string
               format: date-time


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

This PR implements a database migration to add the necessary table columns to track when a bucket, object, or its versions were last synced:
* `version.lastModifiedDate`
* `object.lastSyncedDate`
* `bucket.lastSyncRequestedDate`

All of the above are timestamps with timezones and are `null` by default - they do not get populated during the migration.

The OpenAPI spec has also been updated with these new columns.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
https://apps.nrs.gov.bc.ca/int/jira/browse/SHOWCASE-3406

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
This PR lays the groundwork for [SHOWCASE-3506](https://apps.nrs.gov.bc.ca/int/jira/browse/SHOWCASE-3506).