### PR TITLE
Return full object permissions in object search

### DIFF
--- a/app/src/docs/v1.api-spec.yaml
+++ b/app/src/docs/v1.api-spec.yaml
@@ -416,7 +416,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: "#/components/schemas/DB-Object"
+                  $ref: "#/components/schemas/DB-Object+Permissions"
           headers:
             X-Total-Rows:
               schema:
@@ -2106,6 +2106,58 @@ components:
               example: ac246e31-c807-496c-bc93-cd8bc2f1b2b4
             permCode:
               $ref: "#/components/schemas/PermCode"
+        - $ref: "#/components/schemas/DB-TimestampUserData"
+    DB-Object+Permissions:
+      title: DB Object and Permissions
+      type: object
+      allOf:
+        - type: object
+          required:
+            - id
+            - path
+            - public
+            - active
+          properties:
+            id:
+              type: string
+              description: The primary identifier for this object
+              format: uuid
+              example: ac246e31-c807-496c-bc93-cd8bc2f1b2b4
+            path:
+              type: string
+              description: The canonical S3 path string of the object
+              example: coms/env/foobar.txt
+            public:
+              type: boolean
+              description: Determines whether this object is publicly accessible
+              default: false
+              example: false
+            active:
+              type: boolean
+              description: Determines whether this object is considered active
+              default: true
+              example: true
+            bucketId:
+              type: string
+              description: The primary identifier for the bucket
+              format: uuid
+              example: c05c7650-5f48-4e51-bf17-762e8fc121a1
+            name:
+              type: string
+              description: The filename of the original file uploaded
+              example: foobar.txt
+            lastSyncedDate:
+              type: string
+              format: date-time
+              description: >-
+                Time when the object was last synced with the S3 bucket
+              example: "2022-03-11T23:19:16.343Z"
+              default: null
+            permissions:
+              type: array
+              description: An array of object permissions for the current user. Empty if authenticated via Basic auth. Attribute only returned if `permissions=true` on request.
+              items:
+                $ref: "#/components/schemas/DB-ObjectPermission"
         - $ref: "#/components/schemas/DB-TimestampUserData"
     DB-TagKeyValue:
       title: DB Tag Key Value

--- a/app/src/services/object.js
+++ b/app/src/services/object.js
@@ -164,14 +164,17 @@ const service = {
             results.map(row => {
               // eslint-disable-next-line no-unused-vars
               const { objectPermission, bucketPermission, version, ...object } = row;
-              if (params.permissions) {
-                object.permissions = [];
-                if (objectPermission && params.userId && params.userId !== SYSTEM_USER) {
-                  object.permissions = objectPermission.map(o => o.permCode);
+
+              if (row.id) {
+                if (params.permissions) {
+                  object.permissions = [];
+                  if (objectPermission && params.userId) {
+                    object.permissions = objectPermission.filter(p => p.userId === params.userId);
+                  }
                 }
+                return object;
               }
-              return object;
-            })
+            }).filter(x => x)
           );
         });
 

--- a/app/tests/unit/services/object.spec.js
+++ b/app/tests/unit/services/object.spec.js
@@ -107,6 +107,7 @@ describe('searchObjects', () => {
   // TODO: Add in other untested multiplicity cases
   it('Search and filter for specific object records with permissions and without pagination', async () => {
     const params = {
+      id: '123',
       bucketId: BUCKET_ID,
       active: 'true',
       key: 'key',
@@ -127,7 +128,7 @@ describe('searchObjects', () => {
     expect(result).toHaveProperty('data');
     expect(Array.isArray(result.data)).toBeTruthy();
     expect(result.data[0]).toHaveProperty('permissions');
-    expect(result.data[0].permissions).toEqual(expect.arrayContaining(['READ']));
+    expect(result.data[0].permissions).toEqual([]);
 
     expect(ObjectModel.startTransaction).toHaveBeenCalledTimes(1);
     expect(ObjectModel.query).toHaveBeenCalledTimes(1);


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
# Description

ticket: https://apps.nrs.gov.bc.ca/int/jira/browse/SHOWCASE-3539
if user does objectSearch with permissions=true,
return all permission details for each object

note: the objectSearch query (specifically the hasPermission() modifier has become unwiedly and not written efficiently.
The changes in this pr accommodate for that.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
Documentation (non-breaking change with enhancements to documentation)
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [ ] I have checked that unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->