### PR TITLE
Revert searchObject permission attribute API structure

### DIFF
--- a/app/src/docs/v1.api-spec.yaml
+++ b/app/src/docs/v1.api-spec.yaml
@@ -208,8 +208,8 @@ paths:
         Creates a child bucket record relative to the parent bucket and copies
         the majority of the credential values. Bucket should exist in S3. This
         endpoint will report a collision and the bucketId it collided with if
-        the desired bucket already exists. User requires `MANAGE` permission
-        on the parent bucket to proceed.
+        the desired bucket already exists. User requires `MANAGE` permission on
+        the parent bucket to proceed.
       operationId: createBucketChild
       tags:
         - Bucket
@@ -416,12 +416,29 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: "#/components/schemas/DB-Object"
+                  type: object
+                  allOf:
+                    - $ref: "#/components/schemas/DB-Object"
+                    - type: object
+                      properties:
+                        permissions:
+                          type: array
+                          description: >-
+                            An array of object permissions in the context of the
+                            current user. Yields an empty array if authenticated
+                            via Basic Auth. Property only present if queryparam
+                            `permissions=true` is in request.
+                          items:
+                            type: string
+                            description: An object permission
+                            example: READ
           headers:
             X-Total-Rows:
               schema:
                 type: integer
-              description: Total number of objects matching the search query independent of pagination scope
+              description: >-
+                Total number of objects matching the search query independent of
+                pagination scope
               required: true
         "401":
           $ref: "#/components/responses/Unauthorized"
@@ -653,8 +670,8 @@ paths:
     patch:
       summary: Sets the public flag of an object
       description: >-
-        Toggles the public property for an object and broadcasts to S3 ACL.
-        Sets public to false if public query parameter is not specified.
+        Toggles the public property for an object and broadcasts to S3 ACL. Sets
+        public to false if public query parameter is not specified.
       operationId: togglePublic
       tags:
         - Object
@@ -1717,8 +1734,8 @@ components:
       in: query
       name: limit
       description: >-
-        The page size, number of objects in a page.
-        Must specify page number when defined.
+        The page size, number of objects in a page. Must specify page number
+        when defined.
       schema:
         type: number
         example: 10
@@ -1764,8 +1781,7 @@ components:
     Query-Order:
       in: query
       name: order
-      description: >-
-        Order in ascending or descending. Default to ascending order.
+      description: Order in ascending or descending. Default to ascending order.
       schema:
         type: string
         enum:
@@ -1799,8 +1815,7 @@ components:
     Query-Permissions:
       in: query
       name: permissions
-      description: >-
-        Boolean representing whether or not to include matching permissions
+      description: Boolean representing whether or not to include matching permissions
       schema:
         type: boolean
         example: true
@@ -1808,16 +1823,15 @@ components:
       in: query
       name: page
       description: >-
-        The index of the page to return. The index of first page is 1.
-        Must specify limit when defined.
+        The index of the page to return. The index of first page is 1. Must
+        specify limit when defined.
       schema:
         type: number
         example: 1
     Query-Sort:
       in: query
       name: sort
-      description: >-
-        Any possible object Column.
+      description: Any possible object Column.
       schema:
         type: string
         enum:
@@ -1937,8 +1951,7 @@ components:
               example: coms/env
               maxLength: 255
             lastSyncRequestedDate:
-              description: >-
-                Time when a sync request was last submitted for the bucket
+              description: Time when a sync request was last submitted for the bucket
               type: string
               format: date-time
               example: "2022-03-11T23:19:16.343Z"
@@ -2073,8 +2086,7 @@ components:
             lastSyncedDate:
               type: string
               format: date-time
-              description: >-
-                Time when the object was last synced with the S3 bucket
+              description: Time when the object was last synced with the S3 bucket
               example: "2022-03-11T23:19:16.343Z"
               default: null
         - $ref: "#/components/schemas/DB-TimestampUserData"
@@ -2256,8 +2268,8 @@ components:
               type: string
               format: date-time
               description: >-
-                The object creation date or the last modified date (as exposed by S3's
-                `Last-Modified` header), whichever is the latest.
+                The object creation date or the last modified date (as exposed
+                by S3's `Last-Modified` header), whichever is the latest.
               example: "2022-03-11T23:19:16.343Z"
               default: null
         - $ref: "#/components/schemas/DB-TimestampUserData"
@@ -2316,8 +2328,7 @@ components:
               example: Geospatial Maps
             subKey:
               type: string
-              description: >-
-                The desired S3 child directory name. Must not include `/`.
+              description: The desired S3 child directory name. Must not include `/`.
               maxLength: 255
               example: child
     Request-UpdateBucket:

--- a/app/src/docs/v1.api-spec.yaml
+++ b/app/src/docs/v1.api-spec.yaml
@@ -416,7 +416,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: "#/components/schemas/DB-Object+Permissions"
+                  $ref: "#/components/schemas/DB-Object"
           headers:
             X-Total-Rows:
               schema:
@@ -2106,58 +2106,6 @@ components:
               example: ac246e31-c807-496c-bc93-cd8bc2f1b2b4
             permCode:
               $ref: "#/components/schemas/PermCode"
-        - $ref: "#/components/schemas/DB-TimestampUserData"
-    DB-Object+Permissions:
-      title: DB Object and Permissions
-      type: object
-      allOf:
-        - type: object
-          required:
-            - id
-            - path
-            - public
-            - active
-          properties:
-            id:
-              type: string
-              description: The primary identifier for this object
-              format: uuid
-              example: ac246e31-c807-496c-bc93-cd8bc2f1b2b4
-            path:
-              type: string
-              description: The canonical S3 path string of the object
-              example: coms/env/foobar.txt
-            public:
-              type: boolean
-              description: Determines whether this object is publicly accessible
-              default: false
-              example: false
-            active:
-              type: boolean
-              description: Determines whether this object is considered active
-              default: true
-              example: true
-            bucketId:
-              type: string
-              description: The primary identifier for the bucket
-              format: uuid
-              example: c05c7650-5f48-4e51-bf17-762e8fc121a1
-            name:
-              type: string
-              description: The filename of the original file uploaded
-              example: foobar.txt
-            lastSyncedDate:
-              type: string
-              format: date-time
-              description: >-
-                Time when the object was last synced with the S3 bucket
-              example: "2022-03-11T23:19:16.343Z"
-              default: null
-            permissions:
-              type: array
-              description: An array of object permissions for the current user. Empty if authenticated via Basic auth. Attribute only returned if `permissions=true` on request.
-              items:
-                $ref: "#/components/schemas/DB-ObjectPermission"
         - $ref: "#/components/schemas/DB-TimestampUserData"
     DB-TagKeyValue:
       title: DB Tag Key Value

--- a/app/src/services/object.js
+++ b/app/src/services/object.js
@@ -164,14 +164,16 @@ const service = {
             results.map(row => {
               // eslint-disable-next-line no-unused-vars
               const { objectPermission, bucketPermission, version, ...object } = row;
-              if (params.permissions) {
+              if (row.id && params.permissions) {
                 object.permissions = [];
                 if (objectPermission && params.userId && params.userId !== SYSTEM_USER) {
-                  object.permissions = objectPermission.map(o => o.permCode);
+                  object.permissions = objectPermission
+                    .filter(p => p.userId === params.userId) // Filter down to only current user
+                    .map(o => o.permCode);
                 }
               }
               return object;
-            })
+            }).filter(x => x) // Drop empty row results from the array set
           );
         });
 

--- a/app/src/services/object.js
+++ b/app/src/services/object.js
@@ -164,17 +164,14 @@ const service = {
             results.map(row => {
               // eslint-disable-next-line no-unused-vars
               const { objectPermission, bucketPermission, version, ...object } = row;
-
-              if (row.id) {
-                if (params.permissions) {
-                  object.permissions = [];
-                  if (objectPermission && params.userId) {
-                    object.permissions = objectPermission.filter(p => p.userId === params.userId);
-                  }
+              if (params.permissions) {
+                object.permissions = [];
+                if (objectPermission && params.userId && params.userId !== SYSTEM_USER) {
+                  object.permissions = objectPermission.map(o => o.permCode);
                 }
-                return object;
               }
-            }).filter(x => x)
+              return object;
+            })
           );
         });
 

--- a/app/tests/unit/services/object.spec.js
+++ b/app/tests/unit/services/object.spec.js
@@ -107,7 +107,6 @@ describe('searchObjects', () => {
   // TODO: Add in other untested multiplicity cases
   it('Search and filter for specific object records with permissions and without pagination', async () => {
     const params = {
-      id: '123',
       bucketId: BUCKET_ID,
       active: 'true',
       key: 'key',
@@ -128,7 +127,7 @@ describe('searchObjects', () => {
     expect(result).toHaveProperty('data');
     expect(Array.isArray(result.data)).toBeTruthy();
     expect(result.data[0]).toHaveProperty('permissions');
-    expect(result.data[0].permissions).toEqual([]);
+    expect(result.data[0].permissions).toEqual(expect.arrayContaining(['READ']));
 
     expect(ObjectModel.startTransaction).toHaveBeenCalledTimes(1);
     expect(ObjectModel.query).toHaveBeenCalledTimes(1);

--- a/app/tests/unit/services/object.spec.js
+++ b/app/tests/unit/services/object.spec.js
@@ -107,6 +107,7 @@ describe('searchObjects', () => {
   // TODO: Add in other untested multiplicity cases
   it('Search and filter for specific object records with permissions and without pagination', async () => {
     const params = {
+      id: OBJECT_ID,
       bucketId: BUCKET_ID,
       active: 'true',
       key: 'key',
@@ -117,7 +118,13 @@ describe('searchObjects', () => {
     // We only care about mocking the final 13th chained modify result
     for (let i = 0; i < 10; i++) ObjectModel.modify.mockReturnValueOnce(ObjectModel);
     ObjectModel.modify.mockResolvedValueOnce([{
-      objectPermission: [{ permCode: 'READ' }], ...params
+      objectPermission: [{
+        permCode: 'READ',
+        userId: 'ae8a58f6-62bc-4dd1-acef-79f123609d48'
+      },{
+        permCode: 'UPDATE',
+        userId: 'afcbad71-d2d5-4551-bd8b-18634fd8370e'
+      }], ...params
     }]);
 
     const result = await service.searchObjects(params);
@@ -161,6 +168,7 @@ describe('searchObjects', () => {
     ObjectModel.modify.mockResolvedValueOnce({ total: 0, results: [] });
 
     const params = {
+      id: OBJECT_ID,
       bucketId: BUCKET_ID,
       active: 'true',
       key: 'key',


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

<!-- Describe your changes in detail -->
This PR reverts the API shape changes done in #248 while preserving the user context scoping logic added. The API shape change introduced in the previous PR was unnecessary as it introduced extra unnecessary object parsing overhead that does not yield an improvement in permission conveyance that the original spec was not able to already support.
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Reverts [SHOWCASE-3539](https://apps.nrs.gov.bc.ca/int/jira/browse/SHOWCASE-3539)

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
Documentation (non-breaking change with enhancements to documentation)
Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->