### PR TITLE
Implement lastSyncRequestedDate tracking support

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 # These users will be the default owners for everything in the repo.
 # Unless a later match takes precedence, the following users will be
 # requested for review when someone opens a pull request.
-* @jujaga @norrisng-bc @TimCsaky @jatindersingh93 @wilwong89 @kyle1morel
+* @norrisng-bc @TimCsaky @jatindersingh93 @wilwong89 @kyle1morel

--- a/app/src/docs/v1.api-spec.yaml
+++ b/app/src/docs/v1.api-spec.yaml
@@ -272,6 +272,8 @@ paths:
         preexisting files through the COMS API. This endpoint does not guarantee
         immediately synchronized results. Synchronization latency will be
         affected by the remaining number of objects awaiting synchronization.
+        This endpoint updates the last known successful synchronization request
+        date when invoked.
       tags:
         - Sync
       operationId: syncBucket
@@ -1231,7 +1233,8 @@ paths:
         need to re-upload preexisting files through the COMS API. This endpoint
         does not guarantee immediately synchronized results. Synchronization
         latency will be affected by the remaining number of objects awaiting
-        synchronization.
+        synchronization. This endpoint updates the last known successful
+        synchronization request date when invoked.
       operationId: syncDefault
       tags:
         - Sync

--- a/app/src/services/bucket.js
+++ b/app/src/services/bucket.js
@@ -205,6 +205,7 @@ const service = {
    * @param {string} [data.secretAccessKey] The optional S3 bucket secret access key
    * @param {string} [data.region] The optional S3 bucket region
    * @param {boolean} [data.active] The optional active flag - defaults to true if undefined
+   * @param {string} [data.lastSyncRequestedDate] The optional ISO string formatted date when a sync was last requested
    * @param {object} [etrx=undefined] An optional Objection Transaction object
    * @returns {Promise<object>} The result of running the patch operation
    * @throws The error encountered upon db transaction failure
@@ -223,7 +224,8 @@ const service = {
         secretAccessKey: data.secretAccessKey,
         region: data.region,
         active: data.active,
-        updatedBy: data.userId
+        updatedBy: data.userId,
+        lastSyncRequestedDate: data.lastSyncRequestedDate
       });
 
       if (!etrx) await trx.commit();

--- a/app/tests/unit/controllers/object.spec.js
+++ b/app/tests/unit/controllers/object.spec.js
@@ -119,7 +119,6 @@ describe('addTags', () => {
   const storagePutObjectTaggingSpy = jest.spyOn(storageService, 'putObjectTagging');
   const getCurrentUserIdSpy = jest.spyOn(userService, 'getCurrentUserId');
 
-
   const next = jest.fn();
 
   it('should add the new tags', async () => {
@@ -154,8 +153,7 @@ describe('addTags', () => {
     });
   });
 
-  // TODO: enable this test after a re-factor error reporting
-  it.skip('responds 409 when total tags is greater than 10', async () => {
+  it('responds 409 when total tags is greater than 10', async () => {
     // response from S3
     const getObjectTaggingResponse = {
       TagSet: [
@@ -170,12 +168,12 @@ describe('addTags', () => {
         tagset: { a: '1', b: '2', c: '3', d: '4', e: '5', f: '6', g: '7', h: '8', i: '9', j: '10'}
       }
     };
-
+    getCurrentUserIdSpy.mockReturnValue('user-123');
     storageGetObjectTaggingSpy.mockResolvedValue(getObjectTaggingResponse);
 
     await controller.addTags(req, res, next);
 
-    // expect(next).toHaveReturned(new Problem(422, 'User-defined Tag count limit is 9'));
+    expect(next).toHaveBeenCalledWith(new Problem(409));
   });
 
   it('should concatenate the new tags', async () => {

--- a/app/tests/unit/services/bucket.spec.js
+++ b/app/tests/unit/services/bucket.spec.js
@@ -35,7 +35,8 @@ const data = {
   region: 'region',
   active: 'true',
   createdBy: SYSTEM_USER,
-  userId: SYSTEM_USER
+  userId: SYSTEM_USER,
+  lastSyncRequestedDate: new Date().toISOString()
 };
 
 beforeEach(() => {
@@ -162,7 +163,8 @@ describe('update', () => {
       secretAccessKey: data.secretAccessKey,
       region: data.region,
       active: data.active,
-      updatedBy: data.userId
+      updatedBy: data.userId,
+      lastSyncRequestedDate: data.lastSyncRequestedDate
     });
     expect(bucketTrx.commit).toHaveBeenCalledTimes(1);
   });

--- a/app/tests/unit/services/version.spec.js
+++ b/app/tests/unit/services/version.spec.js
@@ -142,7 +142,19 @@ describe('create', () => {
 });
 
 describe('delete', () => {
-  it.skip('Delete a version record of an object', async () => {
+  const updateIsLatestSpy = jest.spyOn(service, 'updateIsLatest');
+
+  beforeEach(() => {
+    updateIsLatestSpy.mockReset();
+  });
+
+  afterAll(() => {
+    updateIsLatestSpy.mockRestore();
+  });
+
+  it('Delete a version record of an object', async () => {
+    updateIsLatestSpy.mockResolvedValue({});
+
     await service.delete(OBJECT_ID, VERSION_ID);
 
     expect(Version.startTransaction).toHaveBeenCalledTimes(1);
@@ -156,6 +168,8 @@ describe('delete', () => {
     expect(Version.returning).toBeCalledWith('*');
     expect(Version.throwIfNotFound).toHaveBeenCalledTimes(1);
     expect(versionTrx.commit).toHaveBeenCalledTimes(1);
+    expect(updateIsLatestSpy).toHaveBeenCalledTimes(1);
+    expect(updateIsLatestSpy).toHaveBeenCalledWith(OBJECT_ID, expect.anything());
   });
 });
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

<!-- Describe your changes in detail -->
This PR focuses on ensuring that the lastSyncRequestedDate is logged whenever a successful syncBucket or syncDefault request occurs. Also fixes a few long standing skipped unit tests.
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
[SHOWCASE-3507](https://apps.nrs.gov.bc.ca/int/jira/browse/SHOWCASE-3507)

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
Documentation (non-breaking change with enhancements to documentation)
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->