### PR TITLE
Bug fix: Sync public flag on object

### DIFF
--- a/app/src/services/sync.js
+++ b/app/src/services/sync.js
@@ -159,22 +159,18 @@ const service = {
 
         // Case: already synced - record & update public status as needed
         if (comsObject) {
-          if (s3Public === undefined || s3Public === comsObject.public) {
-            response = await objectService.update({
-              id: comsObject.id,
-              userId: userId,
-              lastSyncedDate: new Date().toISOString()
-            }, trx);
-          } else {
-            response = await objectService.update({
-              id: comsObject.id,
-              userId: userId,
-              path: comsObject.path,
-              public: s3Public,
-              lastSyncedDate: new Date().toISOString()
-            }, trx);
-            modified = true;
-          }
+
+          response = await objectService.update({
+            id: comsObject.id,
+            userId: userId,
+            path: comsObject.path,
+            // update if public in s3
+            public: s3Public ? s3Public : comsObject.public,
+            lastSyncedDate: new Date().toISOString()
+          }, trx);
+
+          // if public flag changed mark as modified
+          if (s3Public && !comsObject.public) modified = true;
         }
 
         // Case: not in COMS - insert new COMS object

--- a/app/tests/unit/services/sync.spec.js
+++ b/app/tests/unit/services/sync.spec.js
@@ -424,7 +424,7 @@ describe('syncObject', () => {
     const result = await service.syncObject(path, bucketId);
 
     expect(result).toBeTruthy();
-    expect(result.modified).toBeTruthy();
+    expect(result.modified).toBeFalsy();
     expect(result.object).toEqual(comsObject);
 
     expect(ObjectModel.startTransaction).toHaveBeenCalledTimes(1);
@@ -448,7 +448,7 @@ describe('syncObject', () => {
     expect(objectModelTrx.commit).toHaveBeenCalledTimes(1);
     expect(updateSpy).toHaveBeenCalledTimes(1);
     expect(updateSpy).toHaveBeenCalledWith(expect.objectContaining({
-      id: validUuidv4, path: path, public: false, lastSyncedDate: expect.anything(), userId: SYSTEM_USER
+      id: validUuidv4, path: path, public: true, lastSyncedDate: expect.anything(), userId: SYSTEM_USER
     }), expect.any(Object));
   });
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

bug existed where public file would become non-public after sync.
logic we want is:
- if object is marked as public in s3 then mark as public in coms db.
- if s3 public attribute is false or undefined, keep coms public status.



<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->