### PR TITLE
Keep existing public status after object update

### DIFF
--- a/app/src/controllers/object.js
+++ b/app/src/controllers/object.js
@@ -147,9 +147,6 @@ const controller = {
       const s3Response = await storageService.copyObject(data);
 
       await utils.trxWrapper(async (trx) => {
-        // set public flag to false
-        await objectService.update({ id: objId, userId: userId, path: objPath, public: false });
-
         // create or update version in DB (if a non-versioned object)
         const version = s3Response.VersionId ?
           await versionService.copy(
@@ -848,9 +845,6 @@ const controller = {
       const s3Response = await storageService.copyObject(data);
 
       await utils.trxWrapper(async (trx) => {
-        // set public flag to false
-        await objectService.update({ id: objId, userId: userId, path: objPath, public: false });
-
         // create or update version (if a non-versioned object)
         const version = s3Response.VersionId ?
           await versionService.copy(
@@ -1030,7 +1024,6 @@ const controller = {
         name: filename,
         mimeType: req.currentUpload.mimeType,
         metadata: getMetadata(req.headers),
-        public: false, // New uploads always default to private ACL status
         tags: {
           ...req.query.tagset,
           'coms-id': objId // Enforce `coms-id:<objectId>` tag

--- a/app/tests/unit/controllers/object.spec.js
+++ b/app/tests/unit/controllers/object.spec.js
@@ -104,8 +104,6 @@ describe('addMetadata', () => {
     });
 
     expect(trxWrapperSpy).toHaveBeenCalledTimes(1);
-    expect(updateSpy).toHaveBeenCalledTimes(1);
-    expect(updateSpy).toHaveBeenCalledWith(expect.objectContaining({ public: false }));
     expect(versionCopySpy).toHaveBeenCalledTimes(1);
     expect(metadataAssociateMetadataSpy).toHaveBeenCalledTimes(1);
     expect(tagAssociateTagsSpy).toHaveBeenCalledTimes(1);
@@ -123,7 +121,7 @@ describe('addTags', () => {
 
   it('should add the new tags', async () => {
     // response from S3
-    const getObjectTaggingResponse = { TagSet: []};
+    const getObjectTaggingResponse = { TagSet: [] };
 
     // request object
     const req = {
@@ -165,7 +163,7 @@ describe('addTags', () => {
     const req = {
       params: { objectId: 'xyz-789' },
       query: {
-        tagset: { a: '1', b: '2', c: '3', d: '4', e: '5', f: '6', g: '7', h: '8', i: '9', j: '10'}
+        tagset: { a: '1', b: '2', c: '3', d: '4', e: '5', f: '6', g: '7', h: '8', i: '9', j: '10' }
       }
     };
     getCurrentUserIdSpy.mockReturnValue('user-123');
@@ -567,8 +565,6 @@ describe('replaceMetadata', () => {
     });
 
     expect(trxWrapperSpy).toHaveBeenCalledTimes(1);
-    expect(updateSpy).toHaveBeenCalledTimes(1);
-    expect(updateSpy).toHaveBeenCalledWith(expect.objectContaining({ public: false }));
     expect(versionCopySpy).toHaveBeenCalledTimes(1);
     expect(metadataAssociateMetadataSpy).toHaveBeenCalledTimes(1);
     expect(tagAssociateTagsSpy).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
when uploading a new version or modifying metadata, let object keep existing public status in db.

<!-- Provide a general summary of your changes in the Title above -->
# Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->