### PR TITLE
Add database audit trigger on invite update/delete

### DIFF
--- a/app/src/db/migrations/20240703000000_015-invite-audit-trigger.js
+++ b/app/src/db/migrations/20240703000000_015-invite-audit-trigger.js
@@ -1,0 +1,13 @@
+exports.up = function (knex) {
+  return Promise.resolve()
+    // Create invite audit trigger
+    .then(() => knex.schema.raw(`CREATE TRIGGER audit_invite_trigger
+    AFTER UPDATE OR DELETE ON invite
+    FOR EACH ROW EXECUTE PROCEDURE audit.if_modified_func();`));
+};
+
+exports.down = function (knex) {
+  return Promise.resolve()
+    // Drop invite audit trigger
+    .then(() => knex.schema.raw('DROP TRIGGER IF EXISTS audit_invite_trigger ON invite'));
+};


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

<!-- Describe your changes in detail -->
When an invite is used, it is deleted from the `invite` table. This deletion is now logged to the audit table via a database trigger (as is already the case for other audited actions).

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
https://apps.nrs.gov.bc.ca/int/jira/browse/SHOWCASE-3680

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
As is the case with the existing audit triggers, the new trigger will execute on updates and deletes.

At the moment, however, it effectively only runs on delete since there's no mechanism to modify invites after creation.