### PR TITLE
Allow Content-Disposition types other than attachment

### DIFF
--- a/app/src/docs/v1.api-spec.yaml
+++ b/app/src/docs/v1.api-spec.yaml
@@ -1613,7 +1613,7 @@ components:
       schema:
         type: string
         description: >-
-          A valid RFC 6266 header. Must be of type `attachment` with either a
+          A valid RFC 6266 header. Must include a type with either a
           `filename` or `filename*` parameter using the encoding defined in RFC
           8187 (normally UTF-8). For example, `skwc’әnjíłc.txt` must be
           represented as a url-encoded string

--- a/app/src/middleware/upload.js
+++ b/app/src/middleware/upload.js
@@ -25,8 +25,7 @@ const currentUpload = (strict = false) => {
     const disposition = req.get('Content-Disposition');
     if (disposition) {
       try {
-        const { type, parameters } = contentDisposition.parse(disposition);
-        if (strict && !type || type !== 'attachment') throw new Error('Disposition type is not \'attachment\'');
+        const parameters = contentDisposition.parse(disposition).parameters;
         if (strict && !parameters?.filename) throw new Error('Disposition missing \'filename\' parameter');
         filename = parameters?.filename;
       } catch (e) {

--- a/app/tests/unit/middleware/upload.spec.js
+++ b/app/tests/unit/middleware/upload.spec.js
@@ -63,6 +63,9 @@ describe('currentUpload', () => {
       contentLength: 539, filename: 'foo.txt', mimeType: 'text/plain'
     }, true, 539, 'attachment; filename="foo.txt"', 'text/plain'],
     [1, {
+      contentLength: 539, filename: 'foo.txt', mimeType: 'text/plain'
+    }, true, 539, 'xattachment; filename="foo.txt"', 'text/plain'],
+    [1, {
       contentLength: 539, filename: 'föo.txt', mimeType: 'text/plain'
     }, true, 539, 'attachment; filename=foo.txt; filename*=UTF-8\'\'f%C3%B6o.txt', 'text/plain'],
     [1, {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

<!-- Describe your changes in detail -->
`Content-Disposition` types other than `attachment` are now allowed. 

The following are still required, however:
* A `Content-Disposition` header
* A disposition type of some sort
* `filename`/`filename*`

<!-- Why is this change required? What problem does it solve? -->
[RFC 6266](https://datatracker.ietf.org/doc/html/rfc6266#section-4.1) had no such requirement where the type must be `attachment`.

<!-- If it fixes an open issue, please link to the issue here. -->
https://apps.nrs.gov.bc.ca/int/jira/browse/SHOWCASE-3716

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
COMS didn't even really use the disposition type in the first place, but it still needs the `Content-Disposition` header because that's where it gets the filename.