### PR TITLE
Configure PR Deployments to Share DEV master Postgres Cluster

### DIFF
--- a/.github/actions/deploy-to-environment/action.yaml
+++ b/.github/actions/deploy-to-environment/action.yaml
@@ -25,6 +25,9 @@ inputs:
   openshift_token:
     description: Openshift Service Account Token
     required: true
+  deploy_postgres:
+    description: Should Postgres database be installed for this release
+    default: "true"
 
 runs:
   using: composite
@@ -58,6 +61,7 @@ runs:
         --set image.tag=sha-$(git rev-parse --short HEAD)
         --set route.host=${{ inputs.acronym }}-${{ inputs.namespace_environment }}-${{ inputs.job_name }}.apps.silver.devops.gov.bc.ca
         --set postgres.name=postgres-${{ inputs.job_name }}
+        --set postgres.enabled=${{ inputs.deploy_postgres }}
         --timeout 15m
         --wait
 

--- a/.github/workflows/on-pr-closed.yaml
+++ b/.github/workflows/on-pr-closed.yaml
@@ -40,6 +40,33 @@ jobs:
         run: |
           helm uninstall --namespace ${{ env.NAMESPACE_PREFIX }}-dev pr-${{ github.event.number }} --timeout 10m --wait
           oc delete --namespace ${{ env.NAMESPACE_PREFIX }}-dev cm,secret --selector app.kubernetes.io/instance=pr-${{ github.event.number }}
+
+      # remove user, database and role (named `pr-123`) from postgres
+      - name: Remove PR user and database from postgres.
+        shell: bash
+        run: |
+          USER_TO_REMOVE='{"databases":["pr-${{ github.event.number }}"],"name":"pr-${{ github.event.number }}"}'
+
+          echo 'getting current users from postgres'
+          CURRENT_USERS=$(oc get PostgresCluster/postgres-master -o json | jq '.spec.users')
+          echo "${CURRENT_USERS}"
+
+          # Remove the user from the list, 
+          UPDATED_USERS=$(echo "${CURRENT_USERS}" | jq --argjson user "${USER_TO_REMOVE}" 'map(select(. != $user))')
+
+          PATCH_JSON=$(jq -n --argjson users "${UPDATED_USERS}" '{"spec": {"users": $users}}')
+          oc patch PostgresCluster/postgres-master --type=merge -p "${PATCH_JSON}"
+
+          # get primary crunchy pod and remove the role and db
+          CRUNCHY_PG_PRIMARY_POD_NAME=$(oc get pods -l postgres-operator.crunchydata.com/role=master -o json | jq -r '.items[0].metadata.name')
+
+          echo "${CRUNCHY_PG_PRIMARY_POD_NAME}"
+          oc exec "${CRUNCHY_PG_PRIMARY_POD_NAME}" -- psql -c "DROP DATABASE \"pr-${{ github.event.number }}\" --cascade"
+          oc exec "${CRUNCHY_PG_PRIMARY_POD_NAME}" -- psql -c "DROP ROLE \"pr-${{ github.event.number }}\" --cascade"
+          echo 'database and role deleted'
+
+          exit 0
+
       - name: Remove Release Comment on PR
         uses: marocchino/sticky-pull-request-comment@v2.9.0
         with:

--- a/.github/workflows/on-pr-opened.yaml
+++ b/.github/workflows/on-pr-opened.yaml
@@ -42,7 +42,7 @@ jobs:
       url: https://${{ env.ACRONYM }}-dev-pr-${{ github.event.number }}.apps.silver.devops.gov.bc.ca
     runs-on: ubuntu-latest
     needs: build
-    timeout-minutes: 12
+    timeout-minutes: 12 # increase for crunchyDB ?
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -52,11 +52,48 @@ jobs:
           app_name: ${{ env.APP_NAME }}
           acronym: ${{ env.ACRONYM }}
           environment: pr
+          deploy_postgres: false
           job_name: pr-${{ github.event.number }}
           namespace_prefix: ${{ env.NAMESPACE_PREFIX }}
           namespace_environment: dev
           openshift_server: ${{ secrets.OPENSHIFT_SERVER }}
           openshift_token: ${{ secrets.OPENSHIFT_TOKEN }}
+
+      - name: Login to OpenShift Cluster
+        uses: redhat-actions/oc-login@v1
+        with:
+          openshift_server_url: ${{ secrets.OPENSHIFT_SERVER }}
+          openshift_token: ${{ secrets.OPENSHIFT_TOKEN }}
+          insecure_skip_tls_verify: true
+          namespace: ${{ env.NAMESPACE_PREFIX }}-dev
+
+      # TODO: does pr-123 user need to own database pr-123 in order to connect run knex migrations?
+      - name: Add PR specific user to Crunchy DB
+        shell: bash
+        run: |
+          echo 'Adding PR specific user to Crunchy DB'
+          NEW_USER='{"databases":["pr-${{ github.event.number }}"],"name":"pr-${{ github.event.number }}"}'
+          CURRENT_USERS=$(oc get PostgresCluster/postgres-master -o json | jq '.spec.users')
+          echo "${CURRENT_USERS}"
+          # check if current_users already contains the new_user
+          if echo "${CURRENT_USERS}" | jq -e ".[] | select(.name == \"pr-${{ github.event.number }}\")" > /dev/null; then
+            echo "User already exists"
+            exit 0
+          fi
+          UPDATED_USERS=$(echo "${CURRENT_USERS}" | jq --argjson NEW_USER "${NEW_USER}" '. + [$NEW_USER]')
+          PATCH_JSON=$(jq -n --argjson users "${UPDATED_USERS}" '{"spec": {"users": $users}}')
+          oc patch PostgresCluster/postgres-master --type=merge -p "${PATCH_JSON}"
+          # wait for sometime as it takes time to create the user, query the secret and check if it is created, otherwise wait in a loop for 5 rounds
+          for i in {1..5}; do
+          if oc get secret postgres-crunchy-pguser-pr-${{ github.event.number }} -o jsonpath='{.metadata.name}' > /dev/null; then
+              echo "Secret created"
+              break
+          else
+              echo "Secret not created, waiting for 60 seconds"
+              sleep 60
+          fi
+          done
+
       - name: Release Comment on PR
         uses: marocchino/sticky-pull-request-comment@v2
         if: success()

--- a/charts/coms/Chart.yaml
+++ b/charts/coms/Chart.yaml
@@ -3,7 +3,7 @@ name: common-object-management-service
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.5
+version: 1.1.6
 kubeVersion: ">= 1.13.0"
 description: A microservice for managing access control to S3 Objects
 # A chart can be either an 'application' or a 'library' chart.
@@ -28,7 +28,7 @@ sources:
   - https://github.com/bcgov/common-object-management-service
 dependencies:
   - name: postgrescluster
-    version: 1.1.5
+    version: 1.1.6
     repository: "file://../postgres"
     condition: postgres.enabled
     alias: postgres

--- a/charts/coms/templates/deploymentconfig.yaml
+++ b/charts/coms/templates/deploymentconfig.yaml
@@ -1,10 +1,14 @@
-{{- $postgresClusterName := printf "%s-%s" "postgres" .Release.Name -}}
-{{- $dbHostName := printf "%s-%s" $postgresClusterName "pgbouncer" -}}
-{{- $dbSecretName := printf "%s-%s-%s" $postgresClusterName "pguser" (first .Values.postgres.users).name -}}
+{{- $prRelease := "false" -}}
+{{- $dbSecretName := printf "%s-%s" "postgres-master-pguser-app" -}}
+{{ if ne .Release.Name "master" }}
+{{- $prRelease = "true" -}}
+{{- $dbSecretName = printf "%s-%s" "postgres-master-pguser" .Release.Name -}}
+{{ end }}
+{{- $dbHostName := "postgres-master-pgbouncer" -}}
 {{- define "coms.connectsTo" -}}
 apiVersion: apps/v1
 kind: StatefulSet
-name: {{ printf "%s-%s" "postgres" .Release.Name }}
+name: {{ printf "%s-%s" "postgres-master" }}
 {{- end }}
 ---
 apiVersion: apps.openshift.io/v1
@@ -27,7 +31,7 @@ spec:
       {{- toYaml .Values.resources | nindent 6 }}
     rollingParams:
       timeoutSeconds: 600
-      {{- if or .Values.postgres.enabled .Values.config.configMap.DB_ENABLED }}
+      {{- if or .Values.postgres.enabled $prRelease .Values.config.configMap.DB_ENABLED }}
       pre:
         failurePolicy: {{ .Values.failurePolicy }}
         execNewPod:
@@ -113,7 +117,7 @@ spec:
                   key: password
                   name: {{ include "coms.fullname" . }}-basicauth
             {{- end }}
-            {{- if or .Values.postgres.enabled .Values.config.configMap.DB_ENABLED }}
+            {{- if or .Values.postgres.enabled $prRelease .Values.config.configMap.DB_ENABLED }}
             - name: DB_DATABASE
               valueFrom:
                 secretKeyRef:

--- a/charts/postgres/Chart.yaml
+++ b/charts/postgres/Chart.yaml
@@ -3,5 +3,5 @@ name: postgrescluster
 description: A Helm chart for Kubernetes
 type: application
 # The version below should match the version on the PostgresCluster CRD
-version: 1.1.5
+version: 1.1.6
 appVersion: 5.6.0


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

Pipeline changes to:
- not deploy a new crunchydb postgres cluster for PR deployments
- on PR opended: add a database, user and role for the PR deployment of our app (eg: `pr-123`)
- on PR closed: remove database, user and role for PR
- let PR deployment of COMS app share postgres of DEV master release and connect using temporary postgres user (eg `pr-123`)
-  
## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [ ] I have checked that unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->