### PR TITLE
syncObject: delete 'coms-id' tag on new file if id already in use

### DIFF
--- a/app/src/services/object.js
+++ b/app/src/services/object.js
@@ -211,6 +211,30 @@ const service = {
   },
 
   /**
+   * @function exists
+   * Checks if an object db record exists
+   * @param {string} objId The object uuid to read
+   * @param {object} [etrx=undefined] An optional Objection Transaction object
+   * @returns {Promise<object>} true if object exists in db, false otherwise
+   * @throws The error encountered upon db transaction failure
+   */
+  exists: async (objId, etrx = undefined) => {
+    let trx;
+    try {
+      trx = etrx ? etrx : await ObjectModel.startTransaction();
+
+      const response = await ObjectModel.query(trx).findById(objId);
+
+      if (!etrx) await trx.commit();
+
+      return response ? true : false;
+    } catch (err) {
+      if (!etrx && trx) await trx.rollback();
+      throw err;
+    }
+  },
+
+  /**
    * @function update
    * Update an object DB record
    * @param {string} data.id The object uuid

--- a/app/tests/unit/services/object.spec.js
+++ b/app/tests/unit/services/object.spec.js
@@ -226,6 +226,36 @@ describe('read', () => {
   });
 });
 
+describe('exists', () => {
+  it('returns true if coms-id already exists in db ', async () => {
+    ObjectModel.findById.mockResolvedValueOnce(true);
+
+    const result = await service.exists(data.id);
+
+    expect(result).toBeTruthy();
+    expect(ObjectModel.startTransaction).toHaveBeenCalledTimes(1);
+    expect(ObjectModel.query).toHaveBeenCalledTimes(1);
+    expect(ObjectModel.query).toHaveBeenCalledWith(expect.anything());
+    expect(ObjectModel.findById).toHaveBeenCalledTimes(1);
+    expect(ObjectModel.findById).toBeCalledWith(OBJECT_ID);
+    expect(objectModelTrx.commit).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns false if coms-id does not exist in db', async () => {
+    ObjectModel.findById.mockResolvedValueOnce(false);
+
+    const result = await service.exists(data.id);
+
+    expect(result).toBeFalsy();
+    expect(ObjectModel.startTransaction).toHaveBeenCalledTimes(1);
+    expect(ObjectModel.query).toHaveBeenCalledTimes(1);
+    expect(ObjectModel.query).toHaveBeenCalledWith(expect.anything());
+    expect(ObjectModel.findById).toHaveBeenCalledTimes(1);
+    expect(ObjectModel.findById).toBeCalledWith(OBJECT_ID);
+    expect(objectModelTrx.commit).toHaveBeenCalledTimes(1);
+  });
+});
+
 describe('update', () => {
   it('Update an object DB record', async () => {
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

<!-- Describe your changes in detail -->
When syncing, if a object not currently in COMS has a `coms-id` S3 tag with a value already in use inside COMS, delete the S3 tag and re-generate a new object ID before adding it to COMS.

<!-- Why is this change required? What problem does it solve? -->
This resolves a bug with renaming a file and syncing the folder it's in; COMS will mark the file as soft-deleted but fail to pick up the name change (thus resulting in a de-sync between COMS/S3). In BCBox, it will appear as if renaming the file and syncing it removes it.

<!-- If it fixes an open issue, please link to the issue here. -->
https://apps.nrs.gov.bc.ca/int/jira/browse/SHOWCASE-3782

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

### Motivation

*[Please see Jira ticket for a more detailed explanation](https://apps.nrs.gov.bc.ca/int/jira/browse/SHOWCASE-3782)*

S3 doesn't support file renaming; any attempt to do so (e.g. in GeoDrive or any external S3 tool/browser) is actually 2 operations:
1. Create a copy of the existing file with the new name
2. Delete the existing file

In (1), the new copy will include the same S3 tags and metadata as the original.

In (2), if the bucket has file versioning enabled, then it is a soft deletion. For COMS, this means that the old file still fully exists in its database.

When syncing, COMS will detect (2) as a new file and will try to add it to COMS, using the same `coms-id` it sees in its S3 tags. Attempting to re-use the same id will result in database errors, since it's the primary key for a COMS object.

### Consequences on file version history

Unfortunately, the "new" file with the updated name will lose its version history, since it's held by the "old" copy. However, since it's only soft-deleted in a versioned bucket, the file history technically still exists; it's just that it's not associated with the renamed "active" file.

While it's probably technically possible (on *some* level) to have COMS "link" the renamed file to the old soft-deleted one, such that you'd get one continuous file history, this is probably overly complex for limited gain - the 2 files are  completely separate entities in S3, so you'd have to hack together some novel non-S3 concept to have them linked.