### PR TITLE
Sync Buckets recursively

### DIFF
--- a/app/src/components/utils.js
+++ b/app/src/components/utils.js
@@ -62,6 +62,17 @@ const utils = {
   },
 
   /**
+   * @function formatS3KeyForCompare
+   * Format S3 key-prefixes for comparison with bucket.key in COMS db
+   * @param {string} k S3 key prefix. example: photos/docs/
+   * @returns {string} provided key prefix without trailing slash
+   */
+  formatS3KeyForCompare(k) {
+    let key = k.substr(0, k.lastIndexOf('/')); // remove trailing slash and file name
+    return key || '/'; // set empty key to '/' to match convention in COMS db
+  },
+
+  /**
    * @function getBucket
    * Acquire core S3 bucket credential information from database or configuration
    * @param {string} [bucketId=undefined] An optional bucket ID to query database for bucket

--- a/app/src/components/utils.js
+++ b/app/src/components/utils.js
@@ -340,6 +340,24 @@ const utils = {
   },
 
   /**
+   * @function isPrefixOfPath
+   * Predicate function determining if the `path` is a member of or equal to the `prefix` path
+   * @param {string} prefix The base "folder"
+   * @param {string} path The "file" to check
+   * @returns {boolean} True if path is member of prefix. False in all other cases.
+   */
+  isPrefixOfPath(prefix, path) {
+    if (typeof prefix !== 'string' || typeof path !== 'string') return false;
+    // path `/photos/holiday/` (represents a folder) and should be an objects in bucket with key `/photos/holiday`
+    if (prefix === path || prefix + DELIMITER === path) return true;
+
+    const pathParts = path.split(DELIMITER).filter(part => part);
+    const prefixParts = prefix.split(DELIMITER).filter(part => part);
+    return prefixParts.every((part, i) => pathParts[i] === part)
+      && pathParts.filter(part => !prefixParts.includes(part)).length === 1;
+  },
+
+  /**
    * @function isTruthy
    * Returns true if the element name in the object contains a truthy value
    * @param {object} value The object to evaluate

--- a/app/src/controllers/sync.js
+++ b/app/src/controllers/sync.js
@@ -1,9 +1,16 @@
 const { NIL: SYSTEM_USER } = require('uuid');
 
 const errorToProblem = require('../components/errorToProblem');
-const { addDashesToUuid, getCurrentIdentity } = require('../components/utils');
+const { addDashesToUuid, getCurrentIdentity, isAtPath, isTruthy } = require('../components/utils');
 const utils = require('../db/models/utils');
-const { bucketService, objectService, storageService, objectQueueService, userService } = require('../services');
+const {
+  bucketPermissionService,
+  bucketService,
+  objectService,
+  storageService,
+  objectQueueService,
+  userService
+} = require('../services');
 
 const SERVICE = 'ObjectQueueService';
 
@@ -11,18 +18,161 @@ const SERVICE = 'ObjectQueueService';
  * The Sync Controller
  */
 const controller = {
+
   /**
-   * @function syncBucket
-   * Synchronizes a bucket
+   * @function syncBucketRecursive
+   * Synchronizes all objects and subfolders found at the Key and below for the given parent folder (bucket)
+   * NOTE: OIDC users reuire MANAGE permission to do a recursive sync on a folder
+   * All their permissions will be copied to any NEW sub-folders created
    * @param {object} req Express request object
    * @param {object} res Express response object
    * @param {function} next The next callback function
    * @returns {function} Express middleware function
    */
-  async syncBucket(req, res, next) {
+  async syncBucketRecursive(req, res, next) {
     try {
-      // TODO: Consider adding an "all" mode for checking through all known objects and buckets for job enumeration
-      // const allMode = isTruthy(req.query.all);
+      const userId = await userService.getCurrentUserId(getCurrentIdentity(req.currentUser, SYSTEM_USER), SYSTEM_USER);
+      const bucketId = addDashesToUuid(req.params.bucketId);
+      const parentBucket = await bucketService.read(bucketId);
+      // current user's permissions on parent folder
+      const currentUserParentBucketPerms = userId !== SYSTEM_USER ? (await bucketPermissionService.searchPermissions({
+        bucketId: parentBucket.bucketId,
+        userId: userId
+      })).map(p => p.permCode) : [];
+
+      /**
+       * get the two following lists for comparison:
+       */
+      // get parent + child bucket records already in COMS db
+      const dbChildBuckets = await bucketService.searchChildBuckets(parentBucket);
+      let dbBuckets = [parentBucket].concat(dbChildBuckets);
+
+      // get 'folders' that exist below (and including) the parent 'folder'
+      const s3Response = await storageService.listAllObjectVersions({ bucketId: bucketId, precisePath: false });
+      const formatS3KeyForCompare = (k => {
+        let key = k.substr(0, k.lastIndexOf('/')); // remove trailing slash and file name
+        return key ? key : '/'; // if parent is root set as '/' to match convention in COMS db
+      });
+      const s3Keys = [...new Set([
+        ...s3Response.DeleteMarkers.map(object => formatS3KeyForCompare(object.Key)),
+        ...s3Response.Versions.map(object => formatS3KeyForCompare(object.Key)),
+      ])];
+      // console.log('s3Keys', s3Keys);
+
+
+      /**
+       * compare each list and sync (ie create or delete) bucket records in COMS db to match 'folders' that exist in S3
+       * note: we assign all permissions to all users that created parent bucket
+       */
+      // delete buckets not found in S3 from COMS db
+      const oldDbBuckets = dbBuckets.filter(b => !s3Keys.includes(b.key));
+      for (const dbBucket of oldDbBuckets) {
+        await bucketService.delete(dbBucket.bucketId);
+        dbBuckets = dbBuckets.filter(b => b.bucketId != dbBucket.bucketId);
+      }
+      // Create buckets only found in S3 in COMS db
+      const newS3Keys = s3Keys.filter(k => !dbBuckets.map(b => b.key).includes(k));
+      for (const s3Key of newS3Keys) {
+        const data = {
+          bucketName: s3Key.substring(s3Key.lastIndexOf('/') + 1),
+          accessKeyId: parentBucket.accessKeyId,
+          bucket: parentBucket.bucket,
+          endpoint: parentBucket.endpoint,
+          key: s3Key,
+          secretAccessKey: parentBucket.secretAccessKey,
+          region: parentBucket.region ?? undefined,
+          active: parentBucket.active,
+          userId: parentBucket.createdBy ?? SYSTEM_USER,
+          // current user has MANAGE perm on parent folder (see route.hasPermission)
+          // ..so copy all their perms to NEW subfolders
+          permCodes: currentUserParentBucketPerms
+        };
+        const dbResponse = await bucketService.create(data);
+        dbBuckets.push(dbResponse);
+      }
+
+      /**
+       * Sync all the objects found in all the parent and child 'folders'.
+       * by comparing objects in COMS db with the keys of the object found in S3
+       */
+      // get all objects in existing buckets in all 'buckets' in COMS db
+      const dbObjects = await objectService.searchObjects({
+        bucketId: dbBuckets.map(b => b.bucketId)
+      });
+      // get all objects below parent 'key' in S3
+      const s3Objects = s3Response;
+
+      console.log('s3Objects', s3Objects);
+
+
+      /**
+       * merge arrays of objects from COMS db and S3 to form an array of jobs with format:
+       *  [ { path: '/images/img3.jpg', bucketId: '123' }, { path: '/images/album1/img1.jpg', bucketId: '456' } ]
+       */
+      const objects = [...new Set([
+        // objects already in database
+        ...dbObjects.data.map(object => {
+          return {
+            path: object.path,
+            bucketId: object.bucketId
+          };
+        }),
+        // DeleteMarkers found in S3
+        ...s3Objects.DeleteMarkers.map(object => {
+          return {
+            path: object.Key,
+            bucketId: dbBuckets
+              .filter(b => isAtPath(b.key, object.Key))
+              .map(b => b.bucketId)[0]
+          };
+        }),
+        // Versions found in S3
+        ...s3Objects.Versions
+          .filter(v => v.Size > 0) // is an file (not a 'directory')
+          .map(object => {
+            return {
+              path: object.Key,
+              bucketId: dbBuckets
+                .filter(b => isAtPath(b.key, object.Key))
+                .map(b => b.bucketId)[0],
+              // adding current userId will give ALL perms on new objects
+              // and set createdBy on all downstream resources (versions, tags, meta)
+              // userId: userId
+            };
+          })
+      ])];
+      // merge and remove duplicates
+      const jobs = [...new Map(objects.map(o => [o.path, o])).values()];
+
+      // create jobs in COMS db object_queue for each object
+      const response = await utils.trxWrapper(async (trx) => {
+        // update 'lastSyncRequestedDate' value in COMS db for each bucket
+        for (const bucket of dbBuckets) {
+          await bucketService.update({
+            bucketId: bucket.bucketId,
+            userId: userId,
+            lastSyncRequestedDate: new Date().toISOString()
+          }, trx);
+        }
+        return await objectQueueService.enqueue({ jobs: jobs }, trx);
+      });
+      // return number of jobs inserted
+      res.status(202).json(response);
+    } catch (e) {
+      next(errorToProblem(SERVICE, e));
+    }
+  },
+
+  /**
+   * @function syncBucketSingle
+   * Synchronizes objects found at the Key of the given bucket, ignoring subfolders and files after the next delimiter
+   * @param {object} req Express request object
+   * @param {object} res Express response object
+   * @param {function} next The next callback function
+   * @returns {function} Express middleware function
+   */
+  async syncBucketSingle(req, res, next) {
+    try {
       const bucketId = addDashesToUuid(req.params.bucketId);
       const userId = await userService.getCurrentUserId(getCurrentIdentity(req.currentUser, SYSTEM_USER), SYSTEM_USER);
 
@@ -36,7 +186,13 @@ const controller = {
         ...dbResponse.data.map(object => object.path),
         ...s3Response.DeleteMarkers.map(object => object.Key),
         ...s3Response.Versions.map(object => object.Key)
-      ])].map(path => ({ path: path, bucketId: bucketId }));
+      ])].map(path => ({
+        path: path,
+        bucketId: bucketId
+        // adding current userId will give ALL perms on new objects
+        // and set createdBy on all downstream resources (versions, tags, meta)
+        // userId: userId
+      }));
 
       const response = await utils.trxWrapper(async (trx) => {
         await bucketService.update({

--- a/app/src/controllers/sync.js
+++ b/app/src/controllers/sync.js
@@ -1,8 +1,10 @@
 const { NIL: SYSTEM_USER } = require('uuid');
 
 const errorToProblem = require('../components/errorToProblem');
-const { addDashesToUuid, getCurrentIdentity, isAtPath, isTruthy } = require('../components/utils');
+const { addDashesToUuid, getCurrentIdentity, formatS3KeyForCompare, isAtPath } = require('../components/utils');
 const utils = require('../db/models/utils');
+const log = require('../components/log')(module.filename);
+
 const {
   bucketPermissionService,
   bucketService,
@@ -31,43 +33,101 @@ const controller = {
    */
   async syncBucketRecursive(req, res, next) {
     try {
-      const userId = await userService.getCurrentUserId(getCurrentIdentity(req.currentUser, SYSTEM_USER), SYSTEM_USER);
-      const bucketId = addDashesToUuid(req.params.bucketId);
-      const parentBucket = await bucketService.read(bucketId);
-      // current user's permissions on parent folder
-      const currentUserParentBucketPerms = userId !== SYSTEM_USER ? (await bucketPermissionService.searchPermissions({
-        bucketId: parentBucket.bucketId,
-        userId: userId
-      })).map(p => p.permCode) : [];
+      // Wrap all sql operations in a single transaction
+      const response = await utils.trxWrapper(async (trx) => {
 
-      /**
-       * get the two following lists for comparison:
-       */
-      // get parent + child bucket records already in COMS db
-      const dbChildBuckets = await bucketService.searchChildBuckets(parentBucket);
-      let dbBuckets = [parentBucket].concat(dbChildBuckets);
+        // curren userId
+        const userId = await userService.getCurrentUserId(
+          getCurrentIdentity(req.currentUser, SYSTEM_USER),
+          SYSTEM_USER
+        );
+        // parent bucket
+        const bucketId = addDashesToUuid(req.params.bucketId);
+        const parentBucket = await bucketService.read(bucketId);
 
-      // get 'folders' that exist below (and including) the parent 'folder'
-      const s3Response = await storageService.listAllObjectVersions({ bucketId: bucketId, precisePath: false });
-      const formatS3KeyForCompare = (k => {
-        let key = k.substr(0, k.lastIndexOf('/')); // remove trailing slash and file name
-        return key ? key : '/'; // if parent is root set as '/' to match convention in COMS db
+        // current user's permissions on parent bucket (folder)
+        const currentUserParentBucketPerms = userId !== SYSTEM_USER ? (await bucketPermissionService.searchPermissions({
+          bucketId: parentBucket.bucketId,
+          userId: userId
+        })).map(p => p.permCode) : [];
+
+        /**
+         * sync (ie create or delete) bucket records in COMS db to match 'folders' (S3 key prefixes) that exist in S3
+        */
+        // parent + child bucket records already in COMS db
+        const dbChildBuckets = await bucketService.searchChildBuckets(parentBucket);
+        let dbBuckets = [parentBucket].concat(dbChildBuckets);
+        // 'folders' that exist below (and including) the parent 'folder' in S3
+        const s3Response = await storageService.listAllObjectVersions({ bucketId: bucketId, precisePath: false });
+        const s3Keys = [...new Set([
+          ...s3Response.DeleteMarkers.map(object => formatS3KeyForCompare(object.Key)),
+          ...s3Response.Versions.map(object => formatS3KeyForCompare(object.Key)),
+        ])];
+
+        const syncedBuckets = await this.syncBucketRecords(
+          dbBuckets,
+          s3Keys,
+          parentBucket,
+          // assign current user's permissions on parent bucket to new sub-folders (buckets)
+          currentUserParentBucketPerms,
+          trx
+        );
+
+        /**
+         * Queue objects in all the folders for syncing
+         */
+        return await this.queueObjectRecords(syncedBuckets, s3Response, userId, trx);
       });
-      const s3Keys = [...new Set([
-        ...s3Response.DeleteMarkers.map(object => formatS3KeyForCompare(object.Key)),
-        ...s3Response.Versions.map(object => formatS3KeyForCompare(object.Key)),
-      ])];
-      // console.log('s3Keys', s3Keys);
 
+      // return number of jobs inserted
+      res.status(202).json(response);
+    } catch (e) {
+      next(errorToProblem(SERVICE, e));
+    }
+  },
 
-      /**
-       * compare each list and sync (ie create or delete) bucket records in COMS db to match 'folders' that exist in S3
-       * note: we assign all permissions to all users that created parent bucket
-       */
+  /**
+   * @function syncBucketSingle
+   * Synchronizes objects found at the Key of the given bucket, ignoring subfolders and files after the next delimiter
+   * @param {object} req Express request object
+   * @param {object} res Express response object
+   * @param {function} next The next callback function
+   * @returns {function} Express middleware function
+   */
+  async syncBucketSingle(req, res, next) {
+    try {
+      const bucketId = addDashesToUuid(req.params.bucketId);
+      const bucket = await bucketService.read(bucketId);
+      const userId = await userService.getCurrentUserId(getCurrentIdentity(req.currentUser, SYSTEM_USER), SYSTEM_USER);
+
+      const s3Objects = await storageService.listAllObjectVersions({ bucketId: bucketId, filterLatest: true });
+
+      const response = await utils.trxWrapper(async (trx) => {
+        return this.queueObjectRecords([bucket], s3Objects, userId, trx);
+      });
+
+      res.status(202).json(response);
+    } catch (e) {
+      next(errorToProblem(SERVICE, e));
+    }
+  },
+
+  /**
+  * @function syncBucketRecords
+  * Synchronizes (creates / prunes) COMS db bucket records for each 'directry' found in S3
+  * @param {object[]} Array of Bucket models - bucket records already in COMS db before syncing
+  * @param {string[]} s3Keys Array of key prefixes from S3 representing 'directories'
+  * @param {object} Bucket model for the COMS db bucket record of parent bucket
+  * @param {string[]} currentUserParentBucketPerms Array of PermCodes to add to NEW buckets
+ *  @param {object} [trx] An Objection Transaction object
+  * @returns {string[]} And array of bucketId's for bucket records in COMS db
+  */
+  async syncBucketRecords(dbBuckets, s3Keys, parentBucket, currentUserParentBucketPerms, trx) {
+    try {
       // delete buckets not found in S3 from COMS db
       const oldDbBuckets = dbBuckets.filter(b => !s3Keys.includes(b.key));
       for (const dbBucket of oldDbBuckets) {
-        await bucketService.delete(dbBucket.bucketId);
+        await bucketService.delete(dbBucket.bucketId, trx);
         dbBuckets = dbBuckets.filter(b => b.bucketId != dbBucket.bucketId);
       }
       // Create buckets only found in S3 in COMS db
@@ -87,24 +147,34 @@ const controller = {
           // ..so copy all their perms to NEW subfolders
           permCodes: currentUserParentBucketPerms
         };
-        const dbResponse = await bucketService.create(data);
+
+        const dbResponse = await bucketService.create(data, trx);
         dbBuckets.push(dbResponse);
       }
+      return dbBuckets;
+    }
+    catch (err) {
+      log.error(err.message, { function: 'syncBucketRecords' });
+      throw err;
+    }
+  },
 
-      /**
-       * Sync all the objects found in all the parent and child 'folders'.
-       * by comparing objects in COMS db with the keys of the object found in S3
-       */
+  /**
+   * @function queueObjectRecords
+   * Synchronizes (creates / prunes) COMS db object records with state in S3
+   * @param {object[]} dbBuckets Array of Bucket models in COMS db
+   * @param {object} s3Objects The response from storage.listAllObjectVersions - and
+   * object containg an array of DeleteMarkers and Versions
+   * @param {string} userId the guid of current user
+  *  @param {object} [trx] An Objection Transaction object
+   * @returns {string[]} And array of bucketId's for bucket records in COMS db
+   */
+  async queueObjectRecords(dbBuckets, s3Objects, userId, trx) {
+    try {
       // get all objects in existing buckets in all 'buckets' in COMS db
       const dbObjects = await objectService.searchObjects({
         bucketId: dbBuckets.map(b => b.bucketId)
-      });
-      // get all objects below parent 'key' in S3
-      const s3Objects = s3Response;
-
-      console.log('s3Objects', s3Objects);
-
-
+      }, trx);
       /**
        * merge arrays of objects from COMS db and S3 to form an array of jobs with format:
        *  [ { path: '/images/img3.jpg', bucketId: '123' }, { path: '/images/album1/img1.jpg', bucketId: '456' } ]
@@ -145,66 +215,19 @@ const controller = {
       const jobs = [...new Map(objects.map(o => [o.path, o])).values()];
 
       // create jobs in COMS db object_queue for each object
-      const response = await utils.trxWrapper(async (trx) => {
-        // update 'lastSyncRequestedDate' value in COMS db for each bucket
-        for (const bucket of dbBuckets) {
-          await bucketService.update({
-            bucketId: bucket.bucketId,
-            userId: userId,
-            lastSyncRequestedDate: new Date().toISOString()
-          }, trx);
-        }
-        return await objectQueueService.enqueue({ jobs: jobs }, trx);
-      });
-      // return number of jobs inserted
-      res.status(202).json(response);
-    } catch (e) {
-      next(errorToProblem(SERVICE, e));
-    }
-  },
-
-  /**
-   * @function syncBucketSingle
-   * Synchronizes objects found at the Key of the given bucket, ignoring subfolders and files after the next delimiter
-   * @param {object} req Express request object
-   * @param {object} res Express response object
-   * @param {function} next The next callback function
-   * @returns {function} Express middleware function
-   */
-  async syncBucketSingle(req, res, next) {
-    try {
-      const bucketId = addDashesToUuid(req.params.bucketId);
-      const userId = await userService.getCurrentUserId(getCurrentIdentity(req.currentUser, SYSTEM_USER), SYSTEM_USER);
-
-      const [dbResponse, s3Response] = await Promise.all([
-        objectService.searchObjects({ bucketId: bucketId }),
-        storageService.listAllObjectVersions({ bucketId: bucketId, filterLatest: true })
-      ]);
-
-      // Aggregate and dedupe all file paths to consider
-      const jobs = [...new Set([
-        ...dbResponse.data.map(object => object.path),
-        ...s3Response.DeleteMarkers.map(object => object.Key),
-        ...s3Response.Versions.map(object => object.Key)
-      ])].map(path => ({
-        path: path,
-        bucketId: bucketId
-        // adding current userId will give ALL perms on new objects
-        // and set createdBy on all downstream resources (versions, tags, meta)
-        // userId: userId
-      }));
-
-      const response = await utils.trxWrapper(async (trx) => {
+      // update 'lastSyncRequestedDate' value in COMS db for each bucket
+      for (const bucket of dbBuckets) {
         await bucketService.update({
-          bucketId: bucketId,
+          bucketId: bucket.bucketId,
           userId: userId,
           lastSyncRequestedDate: new Date().toISOString()
         }, trx);
-        return await objectQueueService.enqueue({ jobs: jobs }, trx);
-      });
-      res.status(202).json(response);
-    } catch (e) {
-      next(errorToProblem(SERVICE, e));
+      }
+      return await objectQueueService.enqueue({ jobs: jobs }, trx);
+    }
+    catch (err) {
+      log.error(err.message, { function: 'queueObjectRecords' });
+      throw err;
     }
   },
 

--- a/app/src/db/models/tables/bucket.js
+++ b/app/src/db/models/tables/bucket.js
@@ -48,8 +48,18 @@ class Bucket extends mixin(Model, [
       filterBucketName(query, value) {
         filterILike(query, value, 'bucket.bucketName');
       },
+      filterEndpoint(query, value) {
+        filterILike(query, value, 'bucket.endpoint');
+      },
       filterKey(query, value) {
         filterILike(query, value, 'bucket.key');
+      },
+      filterKeyIsChild(query, value) {
+        if (value && value !== '/') {
+          query.where('bucket.key', 'like', `${value}%`);
+        }
+        query
+          .where('bucket.key', '!=', value);
       },
       filterActive(query, value) {
         if (value !== undefined) query.where('bucket.active', value);

--- a/app/src/docs/v1.api-spec.yaml
+++ b/app/src/docs/v1.api-spec.yaml
@@ -22,44 +22,44 @@ tags:
     description: Operations for managing S3 Bucket(s).
     externalDocs:
       url: >-
-        https://github.com/bcgov/common-object-management-service/wiki/Endpoint-Notes#bucket
+        https://developer.gov.bc.ca/docs/default/component/common-object-management-service/Endpoint-Notes/#bucket
   - name: Metadata
     description: Operations for managing Metadata for S3 Objects.
     externalDocs:
       url: >-
-        https://github.com/bcgov/common-object-management-service/wiki/Endpoint-Notes#metadata
+        https://developer.gov.bc.ca/docs/default/component/common-object-management-service/Endpoint-Notes/#metadata
   - name: Object
     description: Operations directly influencing an S3 Object.
     externalDocs:
       url: >-
-        https://github.com/bcgov/common-object-management-service/wiki/Endpoint-Notes#object
+        https://developer.gov.bc.ca/docs/default/component/common-object-management-service/Endpoint-Notes/#object
   - name: Permission
     description: Operations for managing S3 permissions.
     externalDocs:
       url: >-
-        https://github.com/bcgov/common-object-management-service/wiki/Endpoint-Notes#permission
+        https://developer.gov.bc.ca/docs/default/component/common-object-management-service/Endpoint-Notes/#permissions
   - name: Sync
     description: >-
       Operations for syncing existing buckets and objects. Ensures that external
       S3 modifications are eventually correctly tracked by COMS.
     externalDocs:
       url: >-
-        https://github.com/bcgov/common-object-management-service/wiki/Endpoint-Notes#sync
+        https://developer.gov.bc.ca/docs/default/component/common-object-management-service/Endpoint-Notes/#sync
   - name: Tagging
     description: Operations for managing Tags for S3 Objects.
     externalDocs:
       url: >-
-        https://github.com/bcgov/common-object-management-service/wiki/Endpoint-Notes#tag
+        https://developer.gov.bc.ca/docs/default/component/common-object-management-service/Endpoint-Notes/#tag
   - name: User
     description: Operations to list valid queryable users and identity providers.
     externalDocs:
       url: >-
-        https://github.com/bcgov/common-object-management-service/wiki/Endpoint-Notes#user
+        https://developer.gov.bc.ca/docs/default/component/common-object-management-service/Endpoint-Notes/#user
   - name: Version
     description: Operations to list object versions.
     externalDocs:
       url: >-
-        https://github.com/bcgov/common-object-management-service/wiki/Endpoint-Notes
+        hhttps://developer.gov.bc.ca/docs/default/component/common-object-management-service/Endpoint-Notes/#versions
 paths:
   /bucket:
     put:
@@ -297,6 +297,7 @@ paths:
         - $ref: "#/components/parameters/Header-S3AccessMode-Bucket"
         - $ref: "#/components/parameters/Header-S3AccessMode-Endpoint"
         - $ref: "#/components/parameters/Path-BucketId"
+        - $ref: "#/components/parameters/Query-Recursive"
       responses:
         "202":
           $ref: "#/components/responses/AddedQueueLength"
@@ -1386,9 +1387,10 @@ paths:
     get:
       summary: Synchronize with the default bucket
       description: >-
-        Synchronize the contents of the default bucket with COMS so that it can
-        track and manage objects that are already in the bucket. This avoids the
-        need to re-upload preexisting files through the COMS API. This endpoint
+        Synchronize the contents of the default bucket (specified in environent
+        variables: `OBJECTSTORAGE_*`) with with current state in object storage.
+        This is a 'recursive' sync which will sync objects in all sub-folders.
+        Syncing avoids the need to re-upload preexisting files through the COMS API. This endpoint
         does not guarantee immediately synchronized results. Synchronization
         latency will be affected by the remaining number of objects awaiting
         synchronization. This endpoint updates the last known successful
@@ -2045,6 +2047,15 @@ components:
           - bucketId
           - name
         example: name
+    Query-Recursive:
+      in: query
+      name: recursive
+      description: >-
+        Whether or not to also sync sub-folders inside the provided bucket/folder
+      schema:
+        type: boolean
+        default: false
+        example: 1
     Query-S3VersionId:
       in: query
       name: s3VersionId

--- a/app/src/routes/v1/sync.js
+++ b/app/src/routes/v1/sync.js
@@ -10,7 +10,7 @@ router.use(requireSomeAuth);
 /** Synchronizes the default bucket */
 router.get('/', requireBasicAuth, (req, res, next) => {
   req.params.bucketId = null;
-  syncController.syncBucket(req, res, next);
+  syncController.syncBucketRecursive(req, res, next);
 });
 
 /** Check sync queue size */

--- a/app/src/services/bucket.js
+++ b/app/src/services/bucket.js
@@ -197,6 +197,20 @@ const service = {
   },
 
   /**
+   * @function searchChildBuckets
+   * Get db records for each bucket that acts as a sub-folder of the provided bucket
+   * @param {object} parentBucket a bucket model (record) from the COMS db
+   * @returns {Promise<object[]>} An array of bucket records
+   * @throws If there are no records found
+   */
+  searchChildBuckets: async (parentBucket) => {
+    return Bucket.query()
+      .modify('filterKeyIsChild', parentBucket.key)
+      .modify('filterEndpoint', parentBucket.endpoint)
+      .where('bucket', parentBucket.bucket);
+  },
+
+  /**
    * @function read
    * Get a bucket db record based on bucketId
    * @param {string} bucketId The bucket uuid to read

--- a/app/src/services/bucket.js
+++ b/app/src/services/bucket.js
@@ -200,14 +200,22 @@ const service = {
    * @function searchChildBuckets
    * Get db records for each bucket that acts as a sub-folder of the provided bucket
    * @param {object} parentBucket a bucket model (record) from the COMS db
+   * @param {object} [etrx=undefined] An optional Objection Transaction object
    * @returns {Promise<object[]>} An array of bucket records
    * @throws If there are no records found
    */
-  searchChildBuckets: async (parentBucket) => {
-    return Bucket.query()
-      .modify('filterKeyIsChild', parentBucket.key)
-      .modify('filterEndpoint', parentBucket.endpoint)
-      .where('bucket', parentBucket.bucket);
+  searchChildBuckets: async (parentBucket, etrx = undefined) => {
+    let trx;
+    try {
+      trx = etrx ? etrx : await Bucket.startTransaction();
+      return Bucket.query()
+        .modify('filterKeyIsChild', parentBucket.key)
+        .modify('filterEndpoint', parentBucket.endpoint)
+        .where('bucket', parentBucket.bucket);
+    } catch (err) {
+      if (!etrx && trx) await trx.rollback();
+      throw err;
+    }
   },
 
   /**

--- a/app/src/services/objectQueue.js
+++ b/app/src/services/objectQueue.js
@@ -37,7 +37,7 @@ const service = {
    * Adds a set of jobs to the object queue. If the same job already exists, the existing
    * job will take precedence and will not be reinserted.
    * @param {object[]} options.jobs An array of job objects typically containing `path` and `bucketId` attributes
-   * @param {boolean} [options.full=false] Optional boolean indicating whether to execute full recursive run
+   * @param {boolean} [options.full=false] Optional boolean whether to sync related versions, tags, metadata
    * @param {integer} [options.retries=0] Optional integer indicating how many previous retries this job has had
    * @param {string} [options.createdBy=SYSTEM_USER] Optional uuid attributing which user added the job
    * @param {object} [etrx=undefined] Optional Objection Transaction object

--- a/app/src/validators/bucket.js
+++ b/app/src/validators/bucket.js
@@ -73,6 +73,7 @@ const schema = {
       bucketId: type.uuidv4.required()
     }),
     query: Joi.object({
+      recursive: type.truthy,
     })
   },
 
@@ -100,7 +101,7 @@ const validator = {
   deleteBucket: validate(schema.deleteBucket),
   headBucket: validate(schema.headBucket),
   readBucket: validate(schema.readBucket),
-  syncBucket: validate(schema.readBucket),
+  syncBucket: validate(schema.syncBucket),
   searchBuckets: validate(schema.searchBuckets),
   updateBucket: validate(schema.updateBucket)
 };

--- a/app/tests/unit/controllers/sync.spec.js
+++ b/app/tests/unit/controllers/sync.spec.js
@@ -30,7 +30,7 @@ afterEach(() => {
   jest.resetAllMocks();
 });
 
-describe('syncBucket', () => {
+describe('syncBucketSingle', () => {
   const enqueueSpy = jest.spyOn(objectQueueService, 'enqueue');
   const getCurrentIdentitySpy = jest.spyOn(utils, 'getCurrentIdentity');
   const getCurrentUserIdSpy = jest.spyOn(userService, 'getCurrentUserId');
@@ -40,7 +40,7 @@ describe('syncBucket', () => {
   const updateSpy = jest.spyOn(bucketService, 'update');
   const next = jest.fn();
 
-  it('should enqueue all objects in a bucket', async () => {
+  it('should enqueue all objects in in current \'directory\' in bucket', async () => {
     const USR_IDENTITY = 'xxxy';
     const USR_ID = 'abc-123';
     const req = {
@@ -58,7 +58,7 @@ describe('syncBucket', () => {
     trxWrapperSpy.mockImplementation(callback => callback({}));
     updateSpy.mockResolvedValue({});
 
-    await controller.syncBucket(req, res, next);
+    await controller.syncBucketSingle(req, res, next);
 
     expect(enqueueSpy).toHaveBeenCalledTimes(1);
     expect(listAllObjectVersionsSpy).toHaveBeenCalledTimes(1);
@@ -76,7 +76,7 @@ describe('syncBucket', () => {
     listAllObjectVersionsSpy.mockImplementation(() => { throw new Error('error'); });
     searchObjectsSpy.mockResolvedValue([{ path: path }]);
 
-    await controller.syncBucket(req, res, next);
+    await controller.syncBucketSingle(req, res, next);
 
     expect(enqueueSpy).toHaveBeenCalledTimes(0);
     expect(listAllObjectVersionsSpy).toHaveBeenCalledTimes(1);

--- a/app/tests/unit/controllers/sync.spec.js
+++ b/app/tests/unit/controllers/sync.spec.js
@@ -1,13 +1,7 @@
 const controller = require('../../../src/controllers/sync');
 const {
-  bucketService,
-  objectService,
   objectQueueService,
-  storageService,
-  userService
 } = require('../../../src/services');
-const utils = require('../../../src/components/utils');
-const dbutils = require('../../../src/db/models/utils');
 
 const mockResponse = () => {
   const res = {};
@@ -28,61 +22,6 @@ beforeEach(() => {
 
 afterEach(() => {
   jest.resetAllMocks();
-});
-
-describe('syncBucketSingle', () => {
-  const enqueueSpy = jest.spyOn(objectQueueService, 'enqueue');
-  const getCurrentIdentitySpy = jest.spyOn(utils, 'getCurrentIdentity');
-  const getCurrentUserIdSpy = jest.spyOn(userService, 'getCurrentUserId');
-  const listAllObjectVersionsSpy = jest.spyOn(storageService, 'listAllObjectVersions');
-  const searchObjectsSpy = jest.spyOn(objectService, 'searchObjects');
-  const trxWrapperSpy = jest.spyOn(dbutils, 'trxWrapper');
-  const updateSpy = jest.spyOn(bucketService, 'update');
-  const next = jest.fn();
-
-  it('should enqueue all objects in in current \'directory\' in bucket', async () => {
-    const USR_IDENTITY = 'xxxy';
-    const USR_ID = 'abc-123';
-    const req = {
-      params: bucketId
-    };
-
-    enqueueSpy.mockResolvedValue(1);
-    getCurrentIdentitySpy.mockReturnValue(USR_IDENTITY);
-    getCurrentUserIdSpy.mockReturnValue(USR_ID);
-    listAllObjectVersionsSpy.mockResolvedValue({
-      DeleteMarkers: [{ Key: path }],
-      Versions: [{ Key: path }]
-    });
-    searchObjectsSpy.mockResolvedValue({ total: 1, data: [{ path: path }] });
-    trxWrapperSpy.mockImplementation(callback => callback({}));
-    updateSpy.mockResolvedValue({});
-
-    await controller.syncBucketSingle(req, res, next);
-
-    expect(enqueueSpy).toHaveBeenCalledTimes(1);
-    expect(listAllObjectVersionsSpy).toHaveBeenCalledTimes(1);
-    expect(searchObjectsSpy).toHaveBeenCalledTimes(1);
-    expect(updateSpy).toHaveBeenCalledTimes(1);
-    expect(res.json).toHaveBeenCalledWith(1);
-    expect(res.status).toHaveBeenCalledWith(202);
-    expect(next).toHaveBeenCalledTimes(0);
-  });
-
-  it('should handle unexpected errors', async () => {
-    const req = {
-      params: bucketId
-    };
-    listAllObjectVersionsSpy.mockImplementation(() => { throw new Error('error'); });
-    searchObjectsSpy.mockResolvedValue([{ path: path }]);
-
-    await controller.syncBucketSingle(req, res, next);
-
-    expect(enqueueSpy).toHaveBeenCalledTimes(0);
-    expect(listAllObjectVersionsSpy).toHaveBeenCalledTimes(1);
-    expect(searchObjectsSpy).toHaveBeenCalledTimes(1);
-    expect(next).toHaveBeenCalledTimes(1);
-  });
 });
 
 describe('syncObject', () => {

--- a/charts/coms/Chart.yaml
+++ b/charts/coms/Chart.yaml
@@ -3,7 +3,7 @@ name: common-object-management-service
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.0.3
+version: 2.0.4
 kubeVersion: ">= 1.13.0"
 description: A microservice for managing access control to S3 Objects
 # A chart can be either an 'application' or a 'library' chart.


### PR DESCRIPTION
Creates missing child 'buckets' in COMS db
Syncs provided bucket and all child buckets
Uses object sync queue

add a new `?recursive=true` query param to the `/bucket/:bucketId/sync` endpoint.
Probably need to pull down locally to test with BCBox (modifying the bcbox sync request to include the recursive query param.
see: https://github.com/bcgov/bcbox/blob/410ae8ba73f8662a0341d64b05da14c76473f50b/frontend/src/services/bucketService.ts#L67


<!-- Provide a general summary of your changes in the Title above -->
# Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [ ] I have checked that unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->