### PR TITLE
Add recursive option to bucket delete endpoint

### DIFF
--- a/app/src/docs/v1.api-spec.yaml
+++ b/app/src/docs/v1.api-spec.yaml
@@ -198,9 +198,11 @@ paths:
     delete:
       summary: Deletes a bucket
       description: >-
-        Deletes the bucket record based on bucketId. This request does not
-        dispatch an S3 operation to request the deletion of the associated
-        bucket.
+        Deletes the bucket record (and child objects) from the COMS database, based on bucketId.
+        Providing the 'recursive' parameter will also delete all sub-folders.
+        This request does not dispatch an S3 operation to request the deletion of the associated
+        bucket(s) or delete any objects in object storage, it simply 'de-registers' knowledge of the bucket/folder
+        and objects from the COMS system.
       operationId: deleteBucket
       tags:
         - Bucket
@@ -208,6 +210,7 @@ paths:
         - $ref: "#/components/parameters/Header-S3AccessMode-Bucket"
         - $ref: "#/components/parameters/Header-S3AccessMode-Endpoint"
         - $ref: "#/components/parameters/Path-BucketId"
+        - $ref: "#/components/parameters/Query-Recursive"
       responses:
         "204":
           description: Returns no content success
@@ -285,11 +288,14 @@ paths:
       description: >-
         Synchronize the contents of an existing bucket with COMS so that it can
         track and manage the objects in it. This avoids the need to re-upload
-        preexisting files through the COMS API. This endpoint does not guarantee
+        pre-existing files through the COMS API. This endpoint does not guarantee
         immediately synchronized results. Synchronization latency will be
         affected by the remaining number of objects awaiting synchronization.
         This endpoint updates the last known successful synchronization request
         date when invoked.
+        The `recursive` option will optionally sync sub-folders.
+        Note: The current user (if using OIDC auth) will get the permissions they
+        already have on the parent applied to any NEW sub-folders created in COMS
       tags:
         - Sync
       operationId: syncBucket
@@ -2051,7 +2057,7 @@ components:
       in: query
       name: recursive
       description: >-
-        Whether or not to also sync sub-folders inside the provided bucket/folder
+        Whether or not to also run this operation for sub-folders inside the provided bucket/folder
       schema:
         type: boolean
         default: false

--- a/app/src/validators/bucket.js
+++ b/app/src/validators/bucket.js
@@ -40,6 +40,7 @@ const schema = {
       bucketId: type.uuidv4
     }),
     query: Joi.object({
+      recursive: type.truthy,
     })
   },
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

the bucketDelete endpoint removes a bucket records (and child objects) from the COMS database.
This pr introduces a new `recursive=<boolean>` query param which allows you to delete sub-folders in the process.
 

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->