### PR TITLE
Create/update bucket endpoints: swap HTTP 403/409 response codes when encountering errors with S3 credentials, reword "bucket credentials mismatch" error message

### DIFF
--- a/app/src/controllers/bucket.js
+++ b/app/src/controllers/bucket.js
@@ -90,7 +90,7 @@ const controller = {
       log.warn(`Failure to validate bucket credentials: ${e.message}`, {
         function: '_validateCredentials',
       });
-      throw new Problem(409, {
+      throw new Problem(403, {
         detail: 'Unable to validate supplied credentials for the bucket',
       });
     }
@@ -128,7 +128,7 @@ const controller = {
       if (e instanceof UniqueViolationError) {
         // Grant permissions if credentials precisely match
         response = await bucketService.checkGrantPermissions(data).catch(permErr => {
-          next(new Problem(403, { detail: permErr.message, instance: req.originalUrl }));
+          next(new Problem(409, { detail: permErr.message, instance: req.originalUrl }));
         });
       } else {
         next(errorToProblem(SERVICE, e));

--- a/app/src/services/bucket.js
+++ b/app/src/services/bucket.js
@@ -78,7 +78,8 @@ const service = {
           await bucketPermissionService.addPermissions(bucket.bucketId, perms, data.userId, trx);
         }
       } else {
-        throw new Error('Bucket credential mismatch');
+        throw new Error('The bucket already exists in COMS, but with different credentials. ' +
+          'Please contact your object storage server admin, or whoever added the bucket first.');
       }
 
       if (!etrx) await trx.commit();

--- a/app/tests/unit/controllers/bucket.spec.js
+++ b/app/tests/unit/controllers/bucket.spec.js
@@ -357,7 +357,7 @@ describe('createBucketChild', () => {
     }));
   });
 
-  it('should return a 409 when bucket can not be validated', async () => {
+  it('should return a 403 when bucket can not be validated', async () => {
     const req = {
       body: { bucketName: 'bucketName', subKey: 'subKey' },
       currentUser: CURRENT_USER,
@@ -404,7 +404,7 @@ describe('createBucketChild', () => {
     }));
 
     expect(next).toHaveBeenCalledTimes(1);
-    expect(next).toHaveBeenCalledWith(new Problem(409, {
+    expect(next).toHaveBeenCalledWith(new Problem(403, {
       detail: 'Unable to validate supplied credentials for the bucket'
     }));
   });


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description
<!-- Describe your changes in detail -->
Previously, when creating or updating a bucket:
* A **HTTP 409** is returned when the supplied S3 credentials can't be used to access a bucket.
* A **HTTP 403** is returned when the supplied credentials don't match what's in the COMS database when adding a bucket that already exists in there.

This PR: 
* Swaps the HTTP response codes for these 2 situations - i.e. return **HTTP 403** for invalid S3 credentials, or **HTTP 409** when the S3 credentials don't match.
* Updates the error message for mismatching S3 credentials (i.e. the latter scenario) to be a bit more descriptive.

<!-- Why is this change required? What problem does it solve? -->
These changes better align with the associated HTTP response reason phrase; invalid credentials are better classified as **forbidden (403)**, and mismatching S3 credentials as a **conflict (409)** with the COMS database.

<!-- If it fixes an open issue, please link to the issue here. -->
[SHOWCASE-3941](https://apps.nrs.gov.bc.ca/int/jira/browse/SHOWCASE-3941)

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
https://github.com/bcgov/bcbox/pull/235 exposes the actual COMS API error message to the user (this wasn't the case previously). Updating the error message inside COMS allows a more descriptive error to be shown to the user.

Supporting multiple sets of valid credentials on a bucket at any time will be non-trivial (i.e. credentials may have varying levels of access), so for now, only allow one set of them at any time.