### PR TITLE
Reject PUT /object if combined bucket and file path exceeds S3 maximum

### DIFF
--- a/app/src/components/constants.js
+++ b/app/src/components/constants.js
@@ -60,6 +60,9 @@ module.exports = Object.freeze({
   /** Maximum Content Length supported by S3 CopyObjectCommand */
   MAXFILEOBJECTLENGTH: 5 * 1024 * 1024 * 1024 * 1024, // 5 TB
 
+  /** Maximum object key length supported by S3 */
+  MAXOBJECTKEYLENGTH: 1024, // 1024 B
+
   /** Allowable values for the Metadata Directive parameter */
   MetadataDirective: {
     /** The original metadata is copied to the new version as-is where applicable. */


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

<!-- Describe your changes in detail -->
Reject all `PUT /object` requests with a combined bucket and file path exceeding 1024 bytes (i.e. bucket path + file path + filename, including all `/`'s in between).

<!-- Why is this change required? What problem does it solve? -->
This is because [S3 has a hard limit of 1024 bytes on object keys](https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-keys.html).

Previously, such requests were already being rejected, but with a HTTP 502 (`"detail": "Bucket communication error"`) instead.

<!-- If it fixes an open issue, please link to the issue here. -->
[SHOWCASE-3792](https://apps.nrs.gov.bc.ca/int/jira/browse/SHOWCASE-3792)

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

The focus of the Jira ticket was on potentially problematic characters in bucket (i.e. BCBox folder) names.

However, the only way I was able to break COMS was by creating objects with excessively long filenames that exceed the S3 max key length. This wasn't part of the original ticket, but nonetheless improves handling of potentially problematic bucket/file names.