### PR TITLE
Feature: optionally cascade add/remove bucket permissions operations

### DIFF
--- a/app/src/controllers/bucketPermission.js
+++ b/app/src/controllers/bucketPermission.js
@@ -1,4 +1,6 @@
+const { Permissions } = require('../components/constants');
 const errorToProblem = require('../components/errorToProblem');
+const utils = require('../db/models/utils');
 const {
   addDashesToUuid,
   mixedQueryToArray,
@@ -7,7 +9,7 @@ const {
   isTruthy
 } = require('../components/utils');
 const { NIL: SYSTEM_USER } = require('uuid');
-const { bucketPermissionService, userService } = require('../services');
+const { bucketPermissionService, userService, bucketService } = require('../services');
 
 const SERVICE = 'BucketPermissionService';
 
@@ -15,6 +17,27 @@ const SERVICE = 'BucketPermissionService';
  * The Permission Controller
  */
 const controller = {
+
+  /**
+   * Gets all child bucket records for a given bucket, where the specified user
+   * has MANAGE permission on said child buckets.
+   * @param {string} parentBucketId bucket id of the parent bucket
+   * @param {string} userId user id
+   * @returns {Promise<object[]>} An array of bucket records that are children of the parent,
+   *                              where the user has MANAGE permissions.
+   */
+  async _getChildrenWithManagePerms(parentBucketId, userId) {
+
+    const parentBucket = await bucketService.read(parentBucketId);
+    const allChildren = await bucketService.searchChildBuckets(parentBucket, true, userId);
+
+    const filteredChildren = allChildren.filter(bucket =>
+      bucket.bucketPermission?.some(perm => perm.userId === userId && perm.permCode === Permissions.MANAGE)
+    );
+
+    return filteredChildren;
+  },
+
   /**
    * @function searchPermissions
    * Searches for bucket permissions
@@ -89,11 +112,36 @@ const controller = {
    */
   async addPermissions(req, res, next) {
     try {
-      const userId = await userService.getCurrentUserId(getCurrentIdentity(req.currentUser, SYSTEM_USER));
-      const response = await bucketPermissionService.addPermissions(
-        addDashesToUuid(req.params.bucketId),req.body, userId
-      );
-      res.status(201).json(response);
+      const currUserId = await userService.getCurrentUserId(
+        getCurrentIdentity(req.currentUser, SYSTEM_USER), SYSTEM_USER);
+      const currBucketId = addDashesToUuid(req.params.bucketId);
+
+      if (isTruthy(req.query.recursive)) {
+
+        const parentBucket = await bucketService.read(currBucketId);
+
+        // Only apply permissions to child buckets that currentUser can MANAGE
+        // If the current user is SYSTEM_USER, apply permissions to all child buckets
+        const childBuckets = currUserId !== SYSTEM_USER ?
+          await this._getChildrenWithManagePerms(currBucketId, currUserId) :
+          await bucketService.searchChildBuckets(parentBucket, true, currUserId);
+
+        const allBuckets = [parentBucket, ...childBuckets];
+
+        const responses = await utils.trxWrapper(async (trx) => {
+          return await Promise.all(
+            allBuckets.map(b =>
+              bucketPermissionService.addPermissions(b.bucketId, req.body, currUserId, trx)
+            )
+          );
+        });
+        res.status(201).json(responses.flat());
+      }
+      else {
+        const response = await bucketPermissionService.addPermissions(
+          currBucketId, req.body, currUserId);
+        res.status(201).json(response);
+      }
     } catch (e) {
       next(errorToProblem(SERVICE, e));
     }
@@ -112,13 +160,40 @@ const controller = {
       const userArray = mixedQueryToArray(req.query.userId);
       const userIds = userArray ? userArray.map(id => addDashesToUuid(id)) : userArray;
       const permissions = mixedQueryToArray(req.query.permCode);
-      const response = await bucketPermissionService.removePermissions(req.params.bucketId, userIds, permissions);
-      res.status(200).json(response);
+
+      const currUserId = await userService.getCurrentUserId(
+        getCurrentIdentity(req.currentUser, SYSTEM_USER), SYSTEM_USER);
+      const currBucketId = addDashesToUuid(req.params.bucketId);
+
+      if (isTruthy(req.query.recursive)) {
+
+        const parentBucket = await bucketService.read(currBucketId);
+        // Only apply permissions to child buckets that currentUser can MANAGE
+        // If the current user is SYSTEM_USER, apply permissions to all child buckets
+        const childBuckets = currUserId !== SYSTEM_USER ?
+          await this._getChildrenWithManagePerms(currBucketId, currUserId) :
+          await bucketService.searchChildBuckets(parentBucket, true, currUserId);
+
+        const allBuckets = [parentBucket, ...childBuckets];
+
+        const responses = await utils.trxWrapper(async (trx) => {
+          return await Promise.all(
+            allBuckets.map(b =>
+              bucketPermissionService.removePermissions(b.bucketId, userIds, permissions, trx)
+            )
+          );
+        });
+        res.status(200).json(responses.flat());
+      }
+      else {
+        const response = await bucketPermissionService.removePermissions(currBucketId, userIds, permissions);
+        res.status(200).json(response);
+      }
+
     } catch (e) {
       next(errorToProblem(SERVICE, e));
     }
   },
-
 
 };
 

--- a/app/src/controllers/bucketPermission.js
+++ b/app/src/controllers/bucketPermission.js
@@ -1,4 +1,3 @@
-const { Permissions } = require('../components/constants');
 const errorToProblem = require('../components/errorToProblem');
 const utils = require('../db/models/utils');
 const {
@@ -17,26 +16,6 @@ const SERVICE = 'BucketPermissionService';
  * The Permission Controller
  */
 const controller = {
-
-  /**
-   * Gets all child bucket records for a given bucket, where the specified user
-   * has MANAGE permission on said child buckets.
-   * @param {string} parentBucketId bucket id of the parent bucket
-   * @param {string} userId user id
-   * @returns {Promise<object[]>} An array of bucket records that are children of the parent,
-   *                              where the user has MANAGE permissions.
-   */
-  async _getChildrenWithManagePerms(parentBucketId, userId) {
-
-    const parentBucket = await bucketService.read(parentBucketId);
-    const allChildren = await bucketService.searchChildBuckets(parentBucket, true, userId);
-
-    const filteredChildren = allChildren.filter(bucket =>
-      bucket.bucketPermission?.some(perm => perm.userId === userId && perm.permCode === Permissions.MANAGE)
-    );
-
-    return filteredChildren;
-  },
 
   /**
    * @function searchPermissions
@@ -123,7 +102,7 @@ const controller = {
         // Only apply permissions to child buckets that currentUser can MANAGE
         // If the current user is SYSTEM_USER, apply permissions to all child buckets
         const childBuckets = currUserId !== SYSTEM_USER ?
-          await this._getChildrenWithManagePerms(currBucketId, currUserId) :
+          await bucketService.getChildrenWithManagePermissions(currBucketId, currUserId) :
           await bucketService.searchChildBuckets(parentBucket, true, currUserId);
 
         const allBuckets = [parentBucket, ...childBuckets];
@@ -171,7 +150,7 @@ const controller = {
         // Only apply permissions to child buckets that currentUser can MANAGE
         // If the current user is SYSTEM_USER, apply permissions to all child buckets
         const childBuckets = currUserId !== SYSTEM_USER ?
-          await this._getChildrenWithManagePerms(currBucketId, currUserId) :
+          await bucketService.getChildrenWithManagePermissions(currBucketId, currUserId) :
           await bucketService.searchChildBuckets(parentBucket, true, currUserId);
 
         const allBuckets = [parentBucket, ...childBuckets];

--- a/app/src/db/migrations/20250625000000_016-invite-cascade-child-buckets.js
+++ b/app/src/db/migrations/20250625000000_016-invite-cascade-child-buckets.js
@@ -1,0 +1,23 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = function (knex) {
+  return Promise.resolve()
+    // add recursive column to invite table
+    .then(() => knex.schema.alterTable('invite', table => {
+      table.boolean('recursive').notNullable().defaultTo(false);
+    }));
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = function (knex) {
+  return Promise.resolve()
+    // drop recursive column from invite table
+    .then(() => knex.schema.alterTable('invite', table => {
+      table.dropColumn('recursive');
+    }));
+};

--- a/app/src/db/models/tables/invite.js
+++ b/app/src/db/models/tables/invite.js
@@ -23,6 +23,7 @@ class ObjectModel extends Timestamps(Model) {
         type: { type: 'string', enum: ['bucketId', 'objectId'] },
         expiresAt: { type: 'string', format: 'date-time' },
         permCodes: { type: 'array', items: { type: 'string' } },
+        recursive: { type: 'boolean' },
         ...stamps
       },
       additionalProperties: false

--- a/app/src/docs/v1.api-spec.yaml
+++ b/app/src/docs/v1.api-spec.yaml
@@ -1137,12 +1137,15 @@ paths:
         arbitrary array of permCode and user tuples. This is an idempotent
         operation, so users that already have a requested permission will remain
         unaffected. Only permissions successfully added to COMS will appear in
-        the response.
+        the response. The `recursive` option will also apply the specified
+        permissions to all child buckets where the current user has `MANAGE`
+        permissions.
       operationId: bucketAddPermissions
       tags:
         - Permission
       parameters:
         - $ref: "#/components/parameters/Path-BucketId"
+        - $ref: "#/components/parameters/Query-Recursive"
       requestBody:
         description: >-
           An array of bucket permissions, each containing a `userId` and
@@ -1175,9 +1178,10 @@ paths:
         of users and subset of permissions to revoke. This is an idempotent
         operation, so users that already lack the specified permission(s) will
         remain unaffected. Only permissions successfully removed from COMS will
-        appear in the response. WARNING: Specifying no parameters will delete
-        all permissions associated with a bucket; it is possible to lock
-        yourself out of your own bucket!
+        appear in the response. The `recursive` option will also remove the specified
+        permissions from all child buckets where the current user has `MANAGE`
+        permissions. WARNING: Specifying no parameters will delete all permissions
+        associated with a bucket; it is possible to lock yourself out of your own bucket!
       operationId: bucketRemovePermissions
       tags:
         - Permission
@@ -1185,6 +1189,7 @@ paths:
         - $ref: "#/components/parameters/Path-BucketId"
         - $ref: "#/components/parameters/Query-UserId"
         - $ref: "#/components/parameters/Query-PermCode"
+        - $ref: "#/components/parameters/Query-Recursive"
       responses:
         "200":
           description: Returns an array of deleted permissions

--- a/app/src/docs/v1.api-spec.yaml
+++ b/app/src/docs/v1.api-spec.yaml
@@ -199,10 +199,10 @@ paths:
       summary: Deletes a bucket
       description: >-
         Deletes the bucket record (and child objects) from the COMS database, based on bucketId.
-        When calling this endpoint using OIDC token authentication, the user requires the DELETE
+        When calling this endpoint using OIDC token authentication, the user requires the `DELETE`
         permission for the bucket.
-        Providing the 'recursive' parameter will also delete all sub-folders.
-        The recursive option also requires the OIDC user to have the DELETE permission
+        Providing the `recursive` parameter will also delete all sub-folders.
+        The `recursive` option also requires the OIDC user to have the `DELETE` permission
         on all of these sub-folders otherwise the entire operation will fail.
         This request does not dispatch an S3 operation to request the deletion of the associated
         bucket(s) or delete any objects in object storage, it simply 'de-registers' knowledge of the bucket/folder
@@ -2588,6 +2588,11 @@ components:
             `objectId` must be specified.
           format: uuid
           example: ac246e31-c807-496c-bc93-cd8bc2f1b2b4
+        recursive:
+          type: boolean
+          description: >-
+            Optionally apply permCodes to all sub-folders in the spcified bucket
+          example: true
         email:
           type: string
           description: >-
@@ -2614,7 +2619,7 @@ components:
           type: array
           items:
             type: string
-          description: Optional array of permCode. Defaults to 'READ', if unspecified. Accepts any of `"READ", "CREATE", "UPDATE"` for bucket or  `"READ", "UPDATE"` for objects
+          description: Optional array of permCode. Defaults to `READ`, if unspecified. Accepts any of `"READ", "CREATE", "UPDATE"` for bucket or  `"READ", "UPDATE"` for objects
           example: ["READ", "CREATE", "UPDATE"]
     Request-UpdateBucket:
       title: Request Update Bucket

--- a/app/src/services/invite.js
+++ b/app/src/services/invite.js
@@ -33,7 +33,8 @@ const service = {
         // if permCodes provided set as unique permCodes otherwise just ['READ']
         permCodes: data.permCodes ? Array.from(new Set(data.permCodes)) : ['READ'],
         expiresAt: data.expiresAt,
-        createdBy: data.userId ?? SYSTEM_USER
+        createdBy: data.userId ?? SYSTEM_USER,
+        recursive: data.recursive ?? false
       });
 
       if (!etrx) await trx.commit();

--- a/app/src/validators/bucketPermission.js
+++ b/app/src/validators/bucketPermission.js
@@ -45,6 +45,7 @@ const schema = {
       }).required()
     ).required(),
     query: Joi.object({
+      recursive: type.truthy,
     })
   },
 
@@ -55,6 +56,7 @@ const schema = {
     query: Joi.object({
       userId: scheme.guid,
       permCode: scheme.permCode,
+      recursive: type.truthy
     })
   }
 };

--- a/app/src/validators/invite.js
+++ b/app/src/validators/invite.js
@@ -17,7 +17,7 @@ const schema = {
           then: Joi.array().items(...Object.values(InviteBucketAllowedPermissions)).min(1),
           otherwise: Joi.array().items(...Object.values(InviteObjectAllowedPermissions)).min(1)
         }),
-
+      recursive: type.truthy.optional() // TODO: make forbidden if body.objectId exists
     }).xor('bucketId', 'objectId'),
     query: Joi.object({
     })

--- a/app/tests/unit/controllers/invite.spec.js
+++ b/app/tests/unit/controllers/invite.spec.js
@@ -97,7 +97,7 @@ describe('createInvite', () => {
   });
 
   describe('object', () => {
-    it('should 409 when object not found', async () => {
+    it('should 404 when object not found', async () => {
       const req = { body: { objectId: RESOURCE } };
 
       objectReadSpy.mockRejectedValue({ statusCode: 404 });
@@ -111,7 +111,7 @@ describe('createInvite', () => {
       expect(objectReadSpy).toHaveBeenCalledWith(RESOURCE);
       expect(objectSearchPermissionSpy).toHaveBeenCalledTimes(0);
       expect(next).toHaveBeenCalledTimes(1);
-      expect(next).toHaveBeenCalledWith(new Problem(409));
+      expect(next).toHaveBeenCalledWith(new Problem(404));
     });
 
     it('should 403 when no object manage permission found', async () => {
@@ -261,7 +261,7 @@ describe('createInvite', () => {
   });
 
   describe('bucket', () => {
-    it('should 409 when bucket not found', async () => {
+    it('should 404 when bucket not found', async () => {
       const req = { body: { bucketId: RESOURCE } };
 
       bucketReadSpy.mockRejectedValue({ statusCode: 404 });
@@ -275,7 +275,7 @@ describe('createInvite', () => {
       expect(objectReadSpy).toHaveBeenCalledTimes(0);
       expect(objectSearchPermissionSpy).toHaveBeenCalledTimes(0);
       expect(next).toHaveBeenCalledTimes(1);
-      expect(next).toHaveBeenCalledWith(new Problem(409));
+      expect(next).toHaveBeenCalledWith(new Problem(404));
     });
 
     it('should 403 when no bucket manage permission found', async () => {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description
This PR introduces an optional boolean URL parameter, `recursive`, to the following endpoints:
 * `PUT /permission/bucket/:bucketId` (add bucket permissions)
 * `DELETE /permission/bucket/:bucketId` (remove bucket permissions)

If `true`, the operation is also applied to all child buckets where the current user (i.e. the one making the API call) has `MANAGE` permissions. If the call is being made with basic or S3 auth, the operation is applied to *all* child buckets.

`recursive` defaults to `false`.

Some minor formatting tweaks were also made to the existing OpenAPI spec - specifically, standardizing the formatting for permCodes and URL params to `code blocks`.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
Bucket permissions are essentially encoded as `(bucketId, userId, permCode)` tuples in the the `bucket_permission` database table. 

Because of this, some quirks occur when using basic or S3 auth, caused by `req.currentUser` being `SYSTEM_USER` in such cases.

The `bucket_permission` table will not have any entries where `userId == SYSTEM_USER` (since `SYSTEM_USER` by definition has implicit access to *everything*), so there are places where it is necessary to bypass matching on `userId` when searching the `bucket_permission` table.

This bypassing was added to the existing `bucketService.searchChildBuckets()` function, and is also part of the new code for this new feature. 