### PR TITLE
GET /object: allow no-auth access

### DIFF
--- a/app/src/controllers/object.js
+++ b/app/src/controllers/object.js
@@ -3,6 +3,7 @@ const cors = require('cors');
 const { v4: uuidv4, NIL: SYSTEM_USER } = require('uuid');
 
 const {
+  AuthType,
   DEFAULTCORS,
   DownloadMode,
   MAXCOPYOBJECTLENGTH,
@@ -26,7 +27,8 @@ const {
   mixedQueryToArray,
   toLowerKeys,
   getBucket,
-  renameObjectProperty
+  renameObjectProperty,
+  hasOnlyPermittedKeys
 } = require('../components/utils');
 const utils = require('../db/models/utils');
 
@@ -1057,10 +1059,30 @@ const controller = {
       };
       // if scoping to current user permissions on objects
       if (getConfigBoolean('server.privacyMask')) {
+
+        if (req.currentUser.authType === AuthType.NONE) {
+          const permittedPublicSearchParams = ['bucketId', 'objectId', 'public', 'page', 'limit', 'sort'];
+
+          if (!hasOnlyPermittedKeys(req.query, permittedPublicSearchParams) || !params.public) {
+            throw new Problem(403, {
+              detail: 'User lacks permission to complete this action',
+              instance: req.originalUrl
+            });
+          }
+        }
         params.userId = await userService.getCurrentUserId(getCurrentIdentity(req.currentUser, SYSTEM_USER));
       }
+
       const response = await objectService.searchObjects(params);
-      res.setHeader('X-Total-Rows', response.total).status(200).json(response.data);
+      const redactedFields = ['createdBy', 'updatedBy', 'lastSyncedDate'];
+
+      if (req.currentUser.authType === AuthType.NONE) {
+        const redactedResponseData = response.data.map(object => utils.redactSecrets(object, redactedFields));
+        res.setHeader('X-Total-Rows', response.total).status(200).json(redactedResponseData);
+      }
+      else {
+        res.setHeader('X-Total-Rows', response.total).status(200).json(response.data);
+      }
     } catch (error) {
       next(error);
     }

--- a/app/src/routes/v1/object.js
+++ b/app/src/routes/v1/object.js
@@ -28,7 +28,6 @@ router.put('/',
 
 /** Search for objects */
 router.get('/',
-  requireSomeAuth,
   objectValidator.searchObjects,
   checkS3BasicAccess,
   (req, res, next) => {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

<!-- Describe your changes in detail -->
The `GET /object` (search objects) endpoint can now be accessed without authentication, but with the following restrictions:
* Only a subset of all the available parameters are available: `bucketId`, `objectId`, `public`, `page`, `limit`, `sort`
* The `public` parameter must be set to `true`
* Potentially sensitive fields (`createdBy`, `updatedBy`, `lastSyncedDate`) are redacted in the response

Non-authenticated requests without the above will result in a HTTP 403.

<!-- Why is this change required? What problem does it solve? -->
This is in preparation for the upcoming "public folders" feature.

<!-- If it fixes an open issue, please link to the issue here. -->
https://apps.nrs.gov.bc.ca/int/jira/browse/SHOWCASE-3969

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

***(OpenAPI spec update and unit tests to follow)***

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->