### PR TITLE
GET /object: only blacklist `path` instead of whitelisting a limited subset of params

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -81,11 +81,13 @@ jobs:
         uses: actions/checkout@v4
       - name: Restore Coverage Results
         uses: actions/download-artifact@v4
-      - name: Publish code coverage
-        uses: paambaati/codeclimate-action@v5
-        env:
-          CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
-        with:
-          coverageLocations: |
-            ${{ github.workspace }}/**/lcov.info:lcov
-          prefix: ${{ github.workplace }}
+      # TODO: replace with Qlty as Code Climate has shut down their API:
+      #       https://docs.qlty.sh/migration/coverage
+      # - name: Publish code coverage
+      #   uses: paambaati/codeclimate-action@v5
+      #   env:
+      #     CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
+      #   with:
+      #     coverageLocations: |
+      #       ${{ github.workspace }}/**/lcov.info:lcov
+      #     prefix: ${{ github.workplace }}

--- a/app/src/controllers/object.js
+++ b/app/src/controllers/object.js
@@ -27,8 +27,7 @@ const {
   mixedQueryToArray,
   toLowerKeys,
   getBucket,
-  renameObjectProperty,
-  hasOnlyPermittedKeys
+  renameObjectProperty
 } = require('../components/utils');
 const utils = require('../db/models/utils');
 
@@ -1062,12 +1061,9 @@ const controller = {
 
         if (req.currentUser.authType === AuthType.NONE) {
 
-          const permittedPublicSearchParams = ['bucketId', 'objectId', 'public', 'page', 'limit', 'sort'];
-
           // no-auth requests MUST have all of the following:
-          //  (a) only the permitted search params; (b) ?public=true; (c) an object or bucket id
-          if (!hasOnlyPermittedKeys(req.query, permittedPublicSearchParams) || !params.public ||
-            !(params.bucketId || params.id)) {
+          //  (a) an object or bucket id; (b) ?public=true; (c) not search by S3 path
+          if (!(params.bucketId || params.id) || !params.public || params.path) {
             throw new Problem(403, {
               detail: 'User lacks permission to complete this action',
               instance: req.originalUrl

--- a/app/src/docs/v1.api-spec.yaml
+++ b/app/src/docs/v1.api-spec.yaml
@@ -416,11 +416,11 @@ paths:
         versions of objects. Search criteria on string attributes will match on
         partial results and ignore case sensitivity.
 
-        This endpoint can be used without authentication. If so, some response attributes (`path`, `createdBy`, `updatedBy`, and
-        `lastSynceDate`) are redacted. The following restrictions also apply:
+        This endpoint may be used without authentication. If so, some response attributes (`path`, `createdBy`, `updatedBy`, and
+        `lastSyncedDate`) are redacted. The following restrictions also apply:
         * Only the following query parameters are allowed: `bucketId`, `objectId`, `public`, `page`, `limit`, `sort`
         * `public` must be `true`
-        * An `objectId` or `publicId` must be provided
+        * An `objectId` or `bucketId` must be provided
       operationId: searchObjects
       tags:
         - Object
@@ -1836,7 +1836,7 @@ components:
               example: ac246e31-c807-496c-bc93-cd8bc2f1b2b4
     Query-BucketName:
       in: query
-      name: displayName
+      name: bucketName
       description: A display name given to the bucket on creation
       schema:
         type: string

--- a/app/src/docs/v1.api-spec.yaml
+++ b/app/src/docs/v1.api-spec.yaml
@@ -418,9 +418,10 @@ paths:
 
         This endpoint may be used without authentication. If so, some response attributes (`path`, `createdBy`, `updatedBy`, and
         `lastSyncedDate`) are redacted. The following restrictions also apply:
-        * Only the following query parameters are allowed: `bucketId`, `objectId`, `public`, `page`, `limit`, `sort`
-        * `public` must be `true`
         * An `objectId` or `bucketId` must be provided
+        * `public` must be `true`
+        * The `path` parameter is not permitted
+
       operationId: searchObjects
       tags:
         - Object


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

<!-- Describe your changes in detail -->
This PR is a slight tweak to #312 .

When calling `GET /object` (search objects) without authentication, instead of whitelisting a limited subset of search parameters (`bucketId`, `objectId`, `public`, `page`, `limit`, `sort`), all parameters except for `path` are now allowed.

The other restrictions while no-auth remain; i.e. requiring a `bucketId` or `objectId`, `?public=true` and redaction of some response fields.

No-auth object searches are already scoped by `bucketId`, so allowing other parameters is safe. However, `path` will still be blocked as it can potentially expose the underlying S3 bucket directory structure.

<!-- Why is this change required? What problem does it solve? -->
This allows the object filters in BCBox's `<ObjectTable>` to work without authentication (i.e. for displaying public folders).

Typos in the existing OpenAPI spec have also been fixed.

<!-- If it fixes an open issue, please link to the issue here. -->
https://apps.nrs.gov.bc.ca/int/jira/browse/SHOWCASE-3969

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
N/A