### PR TITLE
Override Express.js default query string array size limit

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -4,6 +4,7 @@ const config = require('config');
 const cors = require('cors');
 const express = require('express');
 const helmet = require('helmet');
+const qs = require('qs');
 
 const { name: appName, version: appVersion } = require('./package.json');
 const { AuthMode, DEFAULTCORS } = require('./src/components/constants');
@@ -31,6 +32,14 @@ let probeId;
 let queueId;
 
 const app = express();
+// Express.js v4 uses `qs` to parse query strings, which has a default max of 20 items per array
+//  (e.g. ?arr[]=value)
+// v5 instead defaults to Node's querystring instead of `qs`
+//  (it's still bundled with Express for now, it just needs to be specified).
+//  https://github.com/expressjs/express/discussions/5783#discussioncomment-13735430
+app.set('query parser', function (str) {
+  return qs.parse(str, { arrayLimit: Infinity });
+});
 app.use(compression());
 app.use(cors(DEFAULTCORS));
 // TODO: extend query param settings further as needed (eg allow bucketId[] for multiple bucket search)

--- a/app/src/middleware/validation.js
+++ b/app/src/middleware/validation.js
@@ -10,16 +10,6 @@ const Problem = require('api-problem');
 const validate = (schema) => {
   return (req, _res, next) => {
 
-    /**
-     * Our implementation of Joi is unable to handle arrays with over 20 items passed in query parameters 
-     * Ensure the object is converted to an array
-     */
-    Object.entries(req.query).forEach(([key, value]) => {
-      if (typeof value === 'object' && !Array.isArray(value)) {
-        req.query[key] = Object.values(value);
-      }
-    });
-
     const validationErrors = Object.entries(schema)
       .map(([prop, def]) => {
         const result = def.validate(req[prop], { abortEarly: false })?.error;

--- a/app/src/routes/v1/bucket.js
+++ b/app/src/routes/v1/bucket.js
@@ -21,7 +21,7 @@ router.put('/',
   express.json(),
   bucketValidator.createBucket,
   checkS3BasicAccess,
-  // checkElevatedUser,
+  checkElevatedUser,
   (req, res, next) => {
     bucketController.createBucket(req, res, next);
   });

--- a/app/src/validators/object.js
+++ b/app/src/validators/object.js
@@ -21,9 +21,7 @@ const schema = {
       objectId: type.uuidv4.required()
     }),
     query: Joi.object({
-      tagset: Joi.any(),
-      // TODO: fix our tagset type
-      // tagset: type.tagset(),
+      tagset: type.tagset(),
       s3VersionId: Joi.string(),
       versionId: type.uuidv4
     }).nand('s3VersionId', 'versionId')
@@ -32,9 +30,7 @@ const schema = {
   createObject: {
     headers: type.metadata(),
     query: Joi.object({
-      tagset: Joi.any(),
-      // TODO: fix our tagset type
-      // tagset: type.tagset(),
+      tagset: type.tagset(),
       bucketId: type.uuidv4.required()
     })
   },
@@ -65,9 +61,7 @@ const schema = {
       objectId: type.uuidv4.required()
     }),
     query: Joi.object({
-      tagset: Joi.any(),
-      // TODO: fix our tagset type
-      // tagset: type.tagset(),
+      tagset: type.tagset(),
       s3VersionId: Joi.string(),
       versionId: type.uuidv4
     }).nand('s3VersionId', 'versionId')
@@ -136,9 +130,7 @@ const schema = {
       objectId: type.uuidv4.required()
     }),
     query: Joi.object({
-      tagset: Joi.any(),
-      // TODO: fix our tagset type
-      // tagset: type.tagset(),
+      tagset: type.tagset(),
       s3VersionId: Joi.string(),
       versionId: type.uuidv4
     }).nand('s3VersionId', 'versionId')
@@ -152,9 +144,7 @@ const schema = {
       name: Joi.string(),
       path: Joi.string().max(1024),
       mimeType: Joi.string().max(255),
-      tagset: Joi.any(),
-      // TODO: fix our tagset type
-      // tagset: type.tagset(),
+      tagset: type.tagset(),
       public: type.truthy,
       active: type.truthy,
       deleteMarker: type.truthy,
@@ -171,9 +161,7 @@ const schema = {
     query: Joi.object({
       bucketId: scheme.guid,
       objectId: scheme.guid,
-      tagset: Joi.any(),
-      // TODO: fix our tagset type
-      // tagset: type.tagset(),
+      tagset: type.tagset(),
     })
   },
 
@@ -200,9 +188,7 @@ const schema = {
       objectId: type.uuidv4.required()
     }),
     query: Joi.object({
-      tagset: Joi.any(),
-      // TODO: fix our tagset type
-      // tagset: type.tagset(),
+      tagset: type.tagset(),
     })
   },
 };

--- a/app/src/validators/tag.js
+++ b/app/src/validators/tag.js
@@ -1,15 +1,13 @@
 const Joi = require('joi');
 
-// const { type } = require('./common');
+const { type } = require('./common');
 const { validate } = require('../middleware/validation');
 
 
 const schema = {
   searchTags: {
     query: Joi.object({
-      tagset: Joi.any(),
-      // TODO: fix our tagset type
-      // tagset: type.tagset(),
+      tagset: type.tagset(),
     })
   }
 };

--- a/app/src/validators/version.js
+++ b/app/src/validators/version.js
@@ -15,9 +15,7 @@ const schema = {
 
   fetchTags: {
     query: Joi.object({
-      tagset: Joi.any(),
-      // TODO: fix our tagset type
-      // tagset: type.tagset(),
+      tagset: type.tagset(),
       s3VersionId: scheme.string,
       versionId: scheme.guid
     }).nand('s3VersionId', 'versionId')

--- a/app/tests/unit/validators/object.spec.js
+++ b/app/tests/unit/validators/object.spec.js
@@ -76,7 +76,7 @@ describe('addTags', () => {
     describe('tagset', () => {
       const tagset = query.keys.tagset;
 
-      it.skip('is the expected schema', () => {
+      it('is the expected schema', () => {
         expect(tagset).toEqual(type.tagset(1, 1).describe());
       });
     });
@@ -105,7 +105,7 @@ describe('createObject', () => {
     describe('tagset', () => {
       const tagset = schema.createObject.query.describe().keys.tagset;
 
-      it.skip('is the expected schema', () => {
+      it('is the expected schema', () => {
         expect(tagset).toEqual(type.tagset().describe());
       });
     });
@@ -202,7 +202,7 @@ describe('deleteTags', () => {
     describe('tagset', () => {
       const tagset = query.keys.tagset;
 
-      it.skip('is the expected schema', () => {
+      it('is the expected schema', () => {
         expect(tagset).toEqual(type.tagset().describe());
       });
     });
@@ -364,7 +364,7 @@ describe('replaceTags', () => {
     describe('tagset', () => {
       const tagset = query.keys.tagset;
 
-      it.skip('is the expected schema', () => {
+      it('is the expected schema', () => {
         expect(tagset).toEqual(type.tagset().describe());
       });
     });
@@ -492,7 +492,7 @@ describe('searchObjects', () => {
     describe('tagset', () => {
       const tagset = query.keys.tagset;
 
-      it.skip('is the expected schema', () => {
+      it('is the expected schema', () => {
         expect(tagset).toEqual(type.tagset().describe());
       });
     });
@@ -666,7 +666,7 @@ describe('updateObject', () => {
     describe('tagset', () => {
       const tagset = query.keys.tagset;
 
-      it.skip('is the expected schema', () => {
+      it('is the expected schema', () => {
         expect(tagset).toEqual(type.tagset().describe());
       });
     });

--- a/app/tests/unit/validators/tag.spec.js
+++ b/app/tests/unit/validators/tag.spec.js
@@ -13,7 +13,7 @@ describe('searchTags', () => {
     describe('tagset', () => {
       const tagset = query.keys.tagset;
 
-      it.skip('is the expected schema', () => {
+      it('is the expected schema', () => {
         expect(tagset).toEqual(type.tagset().describe());
       });
     });

--- a/app/tests/unit/validators/version.spec.js
+++ b/app/tests/unit/validators/version.spec.js
@@ -49,7 +49,7 @@ describe('fetchTags', () => {
 
     const tagset = query.keys.tagset;
 
-    it.skip('is the expected schema', () => {
+    it('is the expected schema', () => {
       expect(tagset).toEqual(type.tagset().describe());
     });
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

<!-- Describe your changes in detail -->
* Override and remove hidden limit of 20 items per query array on COMS API calls
* Re-enable `tagset` validation
* Re-enable `checkElevatedUser` middleware on PUT /bucket - PADS has since implemented an alternative using our S3 auth flow
  * See #313

<!-- Why is this change required? What problem does it solve? -->
COMS API calls containing very large arrays (`bucketId` comes to mind) would otherwise fail. 

The `tagset()` validation was also affected - we limit it to 9 tags max (S3 allows 10, we reserve 1 for `coms-id`), but the validation would fail before the `tagset` size is checked, so if the client request exceeds this limit, it wouldn't be mentioned in the resulting HTTP 422.

<!-- If it fixes an open issue, please link to the issue here. -->
https://apps.nrs.gov.bc.ca/int/jira/browse/SHOWCASE-4255

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

The hidden limit lies within the `qs` npm package (and not Joi, as initially suspected), which Express.js v4 uses internally to handle URL query strings - [by default, it has a limit of 20 items per query array](https://github.com/ljharb/qs/blob/3f5e1c528c967d915096787efbffa73cf6044170/lib/parse.js#L13).

`qs` is replaced by Node's `querystring` in Express.js v5 as the default, though it's still bundled with it. If we update Express.js, this may be a consideration, especially if `qs`is completely removed in later versions (see https://github.com/expressjs/express/discussions/5783#discussioncomment-13735430).

Generally, there are DoS implications on allowing infinitely-sized arrays; this is mitigated by the rate limits imposed via API Gateway, however, so this should be fine.

A previous fix (44e2289, in #317) was meant to address this issue, but it came with side effects due to the change in data structure. The query params from Express.js come in as a JS object, which would then be converted to an array - this left the array values intact, but dropped the keys (which can be problematic since the `tagset()` validator expects an object).


