### PR TITLE
GET /bucket/:bucketId - re-enable hasPermission(READ) middleware

### DIFF
--- a/app/src/routes/v1/bucket.js
+++ b/app/src/routes/v1/bucket.js
@@ -44,6 +44,7 @@ router.head('/:bucketId',
 router.get('/:bucketId',
   bucketValidator.readBucket,
   checkS3BasicAccess,
+  hasPermission(Permissions.READ),
   (req, res, next) => {
     bucketController.readBucket(req, res, next);
   });


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

<!-- Describe your changes in detail -->
Re-enable the `hasPermission(Permissions.READ)` middleware on the `GET /bucket/:bucketId` endpoint.

<!-- Why is this change required? What problem does it solve? -->
This prevents unauthorized access to the bucket details.

<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
Public bucket access is unimpeded, as the `hasPermissions` middleware will check whether the bucket is public.