### PR TITLE
AzureIDIR (IDIR MFA) support

### DIFF
--- a/app/src/controllers/bucket.js
+++ b/app/src/controllers/bucket.js
@@ -17,7 +17,13 @@ const {
 } = require('../components/utils');
 const { redactSecrets } = require('../db/models/utils');
 
-const { bucketService, storageService, userService, bucketPermissionService } = require('../services');
+const {
+  bucketService,
+  storageService,
+  userService,
+  bucketPermissionService,
+  bucketIdpPermissionService
+} = require('../services');
 
 const SERVICE = 'BucketService';
 const secretFields = ['accessKeyId', 'secretAccessKey'];
@@ -184,7 +190,10 @@ const controller = {
       await controller._validateCredentials(childBucket);
       childBucket.userId = await userService.getCurrentUserId(getCurrentIdentity(req.currentUser, SYSTEM_USER));
 
-      const parentPermissions = await bucketPermissionService.searchPermissions({ bucketId: parentBucket.bucketId });
+      const parentPermissions = await bucketPermissionService.searchPermissions(
+        { bucketId: parentBucket.bucketId });
+      const parentIdpPermissions = await bucketIdpPermissionService.searchPermissions(
+        { bucketId: parentBucket.bucketId });
 
       response = await utils.trxWrapper(async (trx) => {
         // Create child bucket
@@ -194,6 +203,11 @@ const controller = {
         if (parentPermissions.length > 0)
           await bucketPermissionService.addPermissions(
             childBucketResp.bucketId, parentPermissions, childBucket.userId, trx);
+
+        // Add parent idp permissions to child bucket
+        if (parentIdpPermissions.length > 0)
+          await bucketIdpPermissionService.addPermissions(
+            childBucketResp.bucketId, parentIdpPermissions, childBucket.userId, trx);
 
         return childBucketResp;
       });

--- a/app/src/middleware/authentication.js
+++ b/app/src/middleware/authentication.js
@@ -118,6 +118,12 @@ const currentUser = async (req, res, next) => {
 
         if (isValid) {
           currentUser.tokenPayload = typeof isValid === 'object' ? isValid : jwt.decode(bearerToken);
+
+          // coerce `azureidir` to `idir` - this allows re-use of the existing SiteMinder IDIR user record
+          if (currentUser.tokenPayload.identity_provider === 'azureidir') {
+            currentUser.tokenPayload.identity_provider = 'idir';
+          }
+
           await userService.login(currentUser.tokenPayload);
         } else {
           throw new Error('Invalid authorization token');

--- a/app/src/middleware/azureidir.js
+++ b/app/src/middleware/azureidir.js
@@ -1,0 +1,24 @@
+/**
+ * @function coerceAzureIDIRQueryParam
+ * Converts `azureidir` to `idir` whenever it appears in the request parameters or body.
+ * This prevents treating of the same (human) user between the 2 IDPs as separate.
+ * @param {object} req Express request object
+ * @param {object} _res Express response object
+ * @param {function} next The next callback function
+ * @returns
+ */
+const coerceAzureIDIRQueryParam = (req, res, next) => {
+  if (req.query.idp) {
+    if (req.query.idp === 'azureidir')
+      req.query.idp = 'idir';
+    else if (Array.isArray(req.query.idp))
+      req.query.idp.map(idpValue => idpValue === 'azureidir' ? 'idir' : idpValue);
+  }
+  else if (req.body.idp === 'azureidir')
+    req.body.idp = 'idir';
+  next();
+};
+
+module.exports = {
+  coerceAzureIDIRQueryParam: coerceAzureIDIRQueryParam
+};

--- a/app/src/routes/v1/permission/bucketIdpPermission.js
+++ b/app/src/routes/v1/permission/bucketIdpPermission.js
@@ -3,6 +3,7 @@ const router = express.Router();
 
 const { Permissions } = require('../../../components/constants');
 const { bucketIdpPermissionController } = require('../../../controllers');
+const { coerceAzureIDIRQueryParam } = require('../../../middleware/azureidir');
 const { bucketIdpPermissionValidator } = require('../../../validators');
 const {
   checkAppMode,
@@ -20,6 +21,7 @@ router.use(requireSomeAuth);
 router.get('/',
   bucketIdpPermissionValidator.searchPermissions,
   checkS3BasicAccess,
+  coerceAzureIDIRQueryParam,
   (req, res, next) => {
     bucketIdpPermissionController.searchPermissions(req, res, next);
   });
@@ -30,6 +32,7 @@ router.get('/:bucketId',
   currentObject,
   checkS3BasicAccess,
   hasPermission(Permissions.READ),
+  coerceAzureIDIRQueryParam,
   (req, res, next) => {
     bucketIdpPermissionController.listPermissions(req, res, next);
   }
@@ -43,6 +46,7 @@ router.put('/:bucketId',
   checkS3BasicAccess,
   checkElevatedUser,
   hasPermission(Permissions.MANAGE),
+  coerceAzureIDIRQueryParam,
   (req, res, next) => {
     bucketIdpPermissionController.addPermissions(req, res, next);
   }

--- a/app/src/routes/v1/permission/objectIdpPermission.js
+++ b/app/src/routes/v1/permission/objectIdpPermission.js
@@ -3,6 +3,7 @@ const router = express.Router();
 
 const { Permissions } = require('../../../components/constants');
 const { objectIdpPermissionController } = require('../../../controllers');
+const { coerceAzureIDIRQueryParam } = require('../../../middleware/azureidir');
 const { objectIdpPermissionValidator } = require('../../../validators');
 const {
   checkAppMode,
@@ -20,6 +21,7 @@ router.use(requireSomeAuth);
 router.get('/',
   objectIdpPermissionValidator.searchPermissions,
   checkS3BasicAccess,
+  coerceAzureIDIRQueryParam,
   (req, res, next) => {
     objectIdpPermissionController.searchPermissions(req, res, next);
   });
@@ -30,6 +32,7 @@ router.get('/:objectId',
   currentObject,
   checkS3BasicAccess,
   hasPermission(Permissions.MANAGE),
+  coerceAzureIDIRQueryParam,
   (req, res, next) => {
     objectIdpPermissionController.listPermissions(req, res, next);
   }
@@ -43,6 +46,7 @@ router.put('/:objectId',
   checkS3BasicAccess,
   checkElevatedUser,
   hasPermission(Permissions.MANAGE),
+  coerceAzureIDIRQueryParam,
   (req, res, next) => {
     objectIdpPermissionController.addPermissions(req, res, next);
   }

--- a/app/src/routes/v1/user.js
+++ b/app/src/routes/v1/user.js
@@ -7,6 +7,7 @@ const {
   checkS3BasicAccess,
   restrictNonIdirUserSearch,
 } = require('../../middleware/authorization');
+const { coerceAzureIDIRQueryParam: coerceAzureIDIRQueryParam } = require('../../middleware/azureidir');
 const { requireSomeAuth } = require('../../middleware/featureToggle');
 
 router.use(checkAppMode);
@@ -21,6 +22,7 @@ router.get('/',
   checkS3BasicAccess,
   userValidator.searchUsers,
   restrictNonIdirUserSearch,
+  coerceAzureIDIRQueryParam,
   (req, res, next) => {
     userController.searchUsers(req, res, next);
   });

--- a/app/src/services/user.js
+++ b/app/src/services/user.js
@@ -158,7 +158,7 @@ const service = {
     return await utils.trxWrapper(async (trx) => {
       // check if user exists in db
       const oldUser = await User.query(trx)
-        .where({ 'identityId': newUser.identityId, idp: newUser.idp })
+        .where({ 'identityId': newUser.identityId })
         .first();
 
       if (!oldUser) {

--- a/app/tests/unit/services/user.spec.js
+++ b/app/tests/unit/services/user.spec.js
@@ -231,7 +231,7 @@ describe('login', () => {
     expect(User.query).toHaveBeenCalledTimes(1);
     expect(User.query).toHaveBeenCalledWith(expect.any(Object));
     expect(User.where).toHaveBeenCalledTimes(1);
-    expect(User.where).toHaveBeenCalledWith({ identityId: user.identityId, idp: user.idp });
+    expect(User.where).toHaveBeenCalledWith({ identityId: user.identityId });
     expect(User.first).toHaveBeenCalledTimes(1);
     expect(User.first).toHaveBeenCalledWith();
 
@@ -249,7 +249,27 @@ describe('login', () => {
     expect(User.query).toHaveBeenCalledTimes(1);
     expect(User.query).toHaveBeenCalledWith(expect.any(Object));
     expect(User.where).toHaveBeenCalledTimes(1);
-    expect(User.where).toHaveBeenCalledWith({ identityId: user.identityId, idp: user.idp });
+    expect(User.where).toHaveBeenCalledWith({ identityId: user.identityId });
+    expect(User.first).toHaveBeenCalledTimes(1);
+    expect(User.first).toHaveBeenCalledWith();
+
+    expect(createUserSpy).toHaveBeenCalledTimes(0);
+    expect(updateUserSpy).toHaveBeenCalledTimes(1);
+    expect(updateUserSpy).toHaveBeenCalledWith(
+      'a96f2809-d6f4-4cef-a02a-3f72edff06d7', expect.objectContaining(user), expect.any(Object)
+    );
+  });
+
+  it('Updates an existing idir user record if user logs in with azureidir', async () => {
+    trxWrapperSpy.mockImplementation(callback => callback({}));
+    User.first.mockResolvedValue({ ...user, idp: 'azureidir', userId: 'a96f2809-d6f4-4cef-a02a-3f72edff06d7' });
+
+    await service.login(token);
+
+    expect(User.query).toHaveBeenCalledTimes(1);
+    expect(User.query).toHaveBeenCalledWith(expect.any(Object));
+    expect(User.where).toHaveBeenCalledTimes(1);
+    expect(User.where).toHaveBeenCalledWith({ identityId: user.identityId });
     expect(User.first).toHaveBeenCalledTimes(1);
     expect(User.first).toHaveBeenCalledWith();
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

<!-- Describe your changes in detail -->
This PR introduces full support for IDIR MFA (a.k.a. `azureidir`) as an identity provider, alongside the existing SiteMinder IDIR (or `idir`). 

`azureidir` was already implicitly supported, since `azureidir`-based JWTs also come from the Pathfinder SSO common Keycloak realm (this allows clients to supply their own JWTs). This PR "merges" the two identities, in the sense that whenever `azureidir` is present in the incoming JWT's `identity_provider` or in the query parameters, it is overwritten/stored as `idir` inside COMS.

Additionally, the behaviour in #311 has now been extended to also include IDP-based permissions. This allows such permissions to be inherited when a child bucket is created.

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
https://apps.nrs.gov.bc.ca/int/jira/browse/SHOWCASE-3713
https://apps.nrs.gov.bc.ca/int/jira/browse/SHOWCASE-4364

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
New feature (non-breaking change which adds functionality)
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

After discussion, it was agreed that overwriting the `identity_provider` field at the auth middleware layer would be the simplest way to merge `idir` and `azureidir`. While this certainly isn't the cleanest, other methods would've entailed modifying significantly more code, edge case handling, updating tests etc.